### PR TITLE
feature: ET (tailscale) no phone home

### DIFF
--- a/analyst/src/cmd/generator/main.go
+++ b/analyst/src/cmd/generator/main.go
@@ -7,11 +7,14 @@ import (
 	"archive/zip"
 	"encoding/json"
 	"fmt"
+	"go/parser"
+	"go/token"
 	"io"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"golang.org/x/mod/modfile"
@@ -195,13 +198,12 @@ func main() {
 		if err != nil {
 			return fmt.Errorf("reading %s: %w", path, err)
 		}
-		original := string(content)
-		replaced := original
-		for old, new := range hostReplacements {
-			replaced = strings.ReplaceAll(replaced, old, new)
+		replaced, err := replaceOutsideComments(content, hostReplacements)
+		if err != nil {
+			return fmt.Errorf("parsing %s: %w", path, err)
 		}
-		if replaced != original {
-			if err := os.WriteFile(path, []byte(replaced), 0644); err != nil {
+		if string(replaced) != string(content) {
+			if err := os.WriteFile(path, replaced, 0644); err != nil {
 				return fmt.Errorf("writing %s: %w", path, err)
 			}
 			log.Printf("Patched Tailscale hostnames in %s", path)
@@ -239,6 +241,54 @@ func main() {
 	}
 
 	log.Println("Done.")
+}
+
+// replaceOutsideComments applies string replacements to Go source code,
+// skipping comments so that documentation and notes are preserved unchanged.
+func replaceOutsideComments(src []byte, replacements map[string]string) ([]byte, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	// Collect comment byte ranges, sorted by position.
+	type span struct{ start, end int }
+	var comments []span
+	for _, cg := range f.Comments {
+		for _, c := range cg.List {
+			comments = append(comments, span{
+				start: fset.Position(c.Pos()).Offset,
+				end:   fset.Position(c.End()).Offset,
+			})
+		}
+	}
+	sort.Slice(comments, func(i, j int) bool {
+		return comments[i].start < comments[j].start
+	})
+
+	// Build result: apply replacements only to non-comment segments.
+	var result []byte
+	pos := 0
+	for _, c := range comments {
+		// Code segment before this comment: apply replacements.
+		code := string(src[pos:c.start])
+		for old, repl := range replacements {
+			code = strings.ReplaceAll(code, old, repl)
+		}
+		result = append(result, code...)
+		// Comment segment: copy verbatim.
+		result = append(result, src[c.start:c.end]...)
+		pos = c.end
+	}
+	// Remaining code after last comment.
+	code := string(src[pos:])
+	for old, repl := range replacements {
+		code = strings.ReplaceAll(code, old, repl)
+	}
+	result = append(result, code...)
+
+	return result, nil
 }
 
 // extractModuleZip extracts a Go module zip to destDir, stripping the

--- a/analyst/src/cmd/generator/main.go
+++ b/analyst/src/cmd/generator/main.go
@@ -4,7 +4,10 @@
 package main
 
 import (
+	"archive/zip"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -15,12 +18,6 @@ import (
 )
 
 func main() {
-	// go mod verify should already have been run by go:generate
-	// so we can be sure that the module files we're about to copy
-	// haven't been tampered with.
-	// TODO: have the pentesters verify this. Do GONOSUMDB or GOSUMDB
-	// env vars affect this?
-
 	// Get absolute path to current module's go.mod file
 	output, err := exec.Command("go", "env", "GOMOD").Output()
 	if err != nil {
@@ -65,33 +62,37 @@ func main() {
 	}
 	log.Printf("Found tailscale.com version %q in go.mod", tailscaleVersion)
 
-	if err := exec.Command("go", "mod", "download", "tailscale.com@"+tailscaleVersion).Run(); err != nil {
+	// Download the module and get the path to its verified zip file.
+	// go mod verify checksums the zip (not the extracted cache directory),
+	// so extracting directly from the zip avoids trusting the cache.
+	output, err = exec.Command("go", "mod", "download", "-json", "tailscale.com@"+tailscaleVersion).Output()
+	if err != nil {
 		log.Fatalf("failed to download tailscale.com module: %v", err)
 	}
+	var modInfo struct {
+		Zip string `json:"Zip"`
+	}
+	if err := json.Unmarshal(output, &modInfo); err != nil {
+		log.Fatalf("failed to parse go mod download output: %v", err)
+	}
+	if modInfo.Zip == "" {
+		log.Fatalf("go mod download did not return a Zip path")
+	}
+	log.Printf("Downloaded module zip: %s", modInfo.Zip)
 
-	// Get Go module cache directory
-	output, err = exec.Command("go", "env", "GOMODCACHE").Output()
-	if err != nil {
-		log.Fatalf("failed to get GOMODCACHE: %v", err)
+	// Verify module checksums against go.sum before extracting.
+	cmd := exec.Command("go", "mod", "verify")
+	if verifyOutput, err := cmd.CombinedOutput(); err != nil {
+		log.Fatalf("go mod verify failed (module may have been tampered with): %v\nOutput: %s", err, verifyOutput)
 	}
-	modCachePath := string(output[:len(output)-1]) // remove trailing newline
-	modPath := filepath.Join(modCachePath, "tailscale.com@"+tailscaleVersion)
-	fmt.Println("Located tailscale.com module:", modPath)
+	log.Println("Module checksums verified against go.sum")
 
-	// Copy the tailscale.com module to build directory
-	cmd := exec.Command("cp", "-r", modPath, tailscaleDir)
-	if output, err := cmd.CombinedOutput(); err != nil {
-		log.Fatalf("failed to copy tailscale.com module to build directory: %v\nOutput: %s", err, output)
+	// Extract the verified zip directly to the build directory.
+	// Module zips prefix all entries with "module@version/"; we strip that.
+	if err := extractModuleZip(modInfo.Zip, tailscaleDir); err != nil {
+		log.Fatalf("failed to extract module zip: %v", err)
 	}
-
-	// chmod -R u+w the copied directory to ensure we have read/write permissions
-	if err := os.Chmod(tailscaleDir, 0755); err != nil {
-		log.Fatalf("failed to set permissions on copied tailscale.com module: %v", err)
-	}
-	if err := exec.Command("chmod", "-R", "u+w", tailscaleDir).Run(); err != nil {
-		log.Fatalf("failed to set permissions on copied tailscale.com module: %v", err)
-	}
-	log.Printf("Copied tailscale.com module to %q\n", tailscaleDir)
+	log.Printf("Extracted module zip to %q", tailscaleDir)
 
 	// Add files from cli directory to the tailscale.com/cmd/tailscale/cli package in the build directory
 	analystCliDir := filepath.Join(analystSrcDir, "cli")
@@ -238,4 +239,61 @@ func main() {
 	}
 
 	log.Println("Done.")
+}
+
+// extractModuleZip extracts a Go module zip to destDir, stripping the
+// "module@version/" prefix that all entries share per the module zip spec.
+func extractModuleZip(zipPath, destDir string) error {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return fmt.Errorf("opening zip: %w", err)
+	}
+	defer r.Close()
+
+	for _, f := range r.File {
+		// Strip the "module@version/" prefix from each entry.
+		_, relPath, ok := strings.Cut(f.Name, "/")
+		if !ok || relPath == "" {
+			continue
+		}
+		destPath := filepath.Join(destDir, relPath)
+
+		// Verify the path doesn't escape the destination (zip slip protection).
+		if !strings.HasPrefix(filepath.Clean(destPath), filepath.Clean(destDir)+string(os.PathSeparator)) {
+			return fmt.Errorf("zip entry %q would escape destination directory", f.Name)
+		}
+
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(destPath, 0755); err != nil {
+				return fmt.Errorf("creating directory %s: %w", destPath, err)
+			}
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+			return fmt.Errorf("creating parent directory for %s: %w", destPath, err)
+		}
+
+		rc, err := f.Open()
+		if err != nil {
+			return fmt.Errorf("opening zip entry %s: %w", f.Name, err)
+		}
+
+		outFile, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+		if err != nil {
+			rc.Close()
+			return fmt.Errorf("creating %s: %w", destPath, err)
+		}
+
+		if _, err := io.Copy(outFile, rc); err != nil {
+			outFile.Close()
+			rc.Close()
+			return fmt.Errorf("writing %s: %w", destPath, err)
+		}
+
+		outFile.Close()
+		rc.Close()
+	}
+
+	return nil
 }

--- a/analyst/src/cmd/generator/main.go
+++ b/analyst/src/cmd/generator/main.go
@@ -165,6 +165,12 @@ func main() {
 		log.Printf("Applied patch %q\n", patchPath)
 	}
 
+	log.Println("Replacing upstream Tailscale DNS fallback servers with empty set...")
+	dnsFallbackPath := filepath.Join(tailscaleDir, "net", "dnsfallback", "dns-fallback-servers.json")
+	if err := os.WriteFile(dnsFallbackPath, []byte(`{"Regions": {}}`+"\n"), 0644); err != nil {
+		log.Fatalf("failed to write dns-fallback-servers.json: %v", err)
+	}
+
 	// Run go mod tidy in the build directory
 	log.Println("Running go mod tidy...")
 	cmd = exec.Command("go", "mod", "tidy")

--- a/analyst/src/cmd/generator/main.go
+++ b/analyst/src/cmd/generator/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"archive/zip"
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"go/parser"
@@ -68,9 +69,9 @@ func main() {
 	// Download the module and get the path to its verified zip file.
 	// go mod verify checksums the zip (not the extracted cache directory),
 	// so extracting directly from the zip avoids trusting the cache.
-	output, err = exec.Command("go", "mod", "download", "-json", "tailscale.com@"+tailscaleVersion).Output()
+	output, err = exec.Command("go", "mod", "download", "-json", "tailscale.com@"+tailscaleVersion).CombinedOutput()
 	if err != nil {
-		log.Fatalf("failed to download tailscale.com module: %v", err)
+		log.Fatalf("failed to download tailscale.com module: %v\nOutput: %s", err, output)
 	}
 	var modInfo struct {
 		Zip string `json:"Zip"`
@@ -202,7 +203,7 @@ func main() {
 		if err != nil {
 			return fmt.Errorf("parsing %s: %w", path, err)
 		}
-		if string(replaced) != string(content) {
+		if !bytes.Equal(replaced, content) {
 			if err := os.WriteFile(path, replaced, 0644); err != nil {
 				return fmt.Errorf("writing %s: %w", path, err)
 			}
@@ -267,26 +268,23 @@ func replaceOutsideComments(src []byte, replacements map[string]string) ([]byte,
 		return comments[i].start < comments[j].start
 	})
 
+	// replaceSegment applies all replacements to a code segment.
+	replaceSegment := func(segment string) string {
+		for old, repl := range replacements {
+			segment = strings.ReplaceAll(segment, old, repl)
+		}
+		return segment
+	}
+
 	// Build result: apply replacements only to non-comment segments.
 	var result []byte
 	pos := 0
 	for _, c := range comments {
-		// Code segment before this comment: apply replacements.
-		code := string(src[pos:c.start])
-		for old, repl := range replacements {
-			code = strings.ReplaceAll(code, old, repl)
-		}
-		result = append(result, code...)
-		// Comment segment: copy verbatim.
+		result = append(result, replaceSegment(string(src[pos:c.start]))...)
 		result = append(result, src[c.start:c.end]...)
 		pos = c.end
 	}
-	// Remaining code after last comment.
-	code := string(src[pos:])
-	for old, repl := range replacements {
-		code = strings.ReplaceAll(code, old, repl)
-	}
-	result = append(result, code...)
+	result = append(result, replaceSegment(string(src[pos:]))...)
 
 	return result, nil
 }
@@ -320,29 +318,35 @@ func extractModuleZip(zipPath, destDir string) error {
 			continue
 		}
 
-		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
-			return fmt.Errorf("creating parent directory for %s: %w", destPath, err)
+		if err := extractZipFile(f, destPath); err != nil {
+			return err
 		}
+	}
 
-		rc, err := f.Open()
-		if err != nil {
-			return fmt.Errorf("opening zip entry %s: %w", f.Name, err)
-		}
+	return nil
+}
 
-		outFile, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
-		if err != nil {
-			rc.Close()
-			return fmt.Errorf("creating %s: %w", destPath, err)
-		}
+// extractZipFile extracts a single file from a zip archive to destPath,
+// creating parent directories as needed.
+func extractZipFile(f *zip.File, destPath string) error {
+	if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+		return fmt.Errorf("creating parent directory for %s: %w", destPath, err)
+	}
 
-		if _, err := io.Copy(outFile, rc); err != nil {
-			outFile.Close()
-			rc.Close()
-			return fmt.Errorf("writing %s: %w", destPath, err)
-		}
+	rc, err := f.Open()
+	if err != nil {
+		return fmt.Errorf("opening zip entry %s: %w", f.Name, err)
+	}
+	defer rc.Close()
 
-		outFile.Close()
-		rc.Close()
+	outFile, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+	if err != nil {
+		return fmt.Errorf("creating %s: %w", destPath, err)
+	}
+	defer outFile.Close()
+
+	if _, err := io.Copy(outFile, rc); err != nil {
+		return fmt.Errorf("writing %s: %w", destPath, err)
 	}
 
 	return nil

--- a/analyst/src/cmd/generator/main.go
+++ b/analyst/src/cmd/generator/main.go
@@ -171,6 +171,46 @@ func main() {
 		log.Fatalf("failed to write dns-fallback-servers.json: %v", err)
 	}
 
+	log.Println("Replacing upstream Tailscale hostnames with example.com...")
+	hostReplacements := map[string]string{
+		"log.tailscale.com":          "log.example.com",
+		"controlplane.tailscale.com": "controlplane.example.com",
+		"login.tailscale.com":        "login.example.com",
+	}
+	err = filepath.WalkDir(tailscaleDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "tstest" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".go") || strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+		original := string(content)
+		replaced := original
+		for old, new := range hostReplacements {
+			replaced = strings.ReplaceAll(replaced, old, new)
+		}
+		if replaced != original {
+			if err := os.WriteFile(path, []byte(replaced), 0644); err != nil {
+				return fmt.Errorf("writing %s: %w", path, err)
+			}
+			log.Printf("Patched Tailscale hostnames in %s", path)
+		}
+		return nil
+	})
+	if err != nil {
+		log.Fatalf("failed to replace Tailscale hostnames: %v", err)
+	}
+
 	// Run go mod tidy in the build directory
 	log.Println("Running go mod tidy...")
 	cmd = exec.Command("go", "mod", "tidy")

--- a/analyst/src/generate.go
+++ b/analyst/src/generate.go
@@ -3,5 +3,5 @@
 
 package main
 
-//go:generate go mod verify
+//go:generate go mod download
 //go:generate go run ./cmd/generator

--- a/android-client/Makefile
+++ b/android-client/Makefile
@@ -11,6 +11,11 @@
 ## For signed release build JKS_PASSWORD must be set to the password for the jks keystore
 ## and JKS_PATH must be set to the path to the jks keystore.
 
+# These tags disable features in Tailscale that reach out to Tailscale-controlled servers
+# ts_omit_clientmetrics excluded: its omit stub is incomplete (missing Type enum)
+# and logtail omission already blocks the only metric exfiltration path.
+GOTAGS := ts_omit_logtail,ts_omit_netlog,ts_omit_captiveportal,ts_omit_clientupdate,ts_omit_usermetrics,ts_omit_cloud
+
 # Reproducibility: default SOURCE_DATE_EPOCH to the last git commit timestamp.
 # CI or F-Droid may override this via the environment.
 export SOURCE_DATE_EPOCH ?= $(shell git log -1 --format=%ct 2>/dev/null || echo 0)
@@ -241,6 +246,7 @@ build-unstripped-aar: $(GOBIN)/gomobile
 	GONOSUMDB=* \
 	GOFLAGS="$(GOFLAGS) -buildvcs=false" \
 	gomobile bind -trimpath -target android -androidapi 26 \
+		-tags $(GOTAGS) \
 		-ldflags "-s -w -buildid= -linkmode=external -extldflags=-Wl,-z,max-page-size=16384 $$(./version-ldflags.sh)" \
 		-o $(ABS_UNSTRIPPED_AAR) ./libtailscale || { echo "gomobile bind failed"; exit 1; }
 	@if [ ! -f $(ABS_UNSTRIPPED_AAR) ]; then \

--- a/control-plane/headscale/config.example.yaml
+++ b/control-plane/headscale/config.example.yaml
@@ -74,7 +74,7 @@ derp:
   server:
     # If enabled, runs the embedded DERP server and merges it into the rest of the DERP config
     # The Headscale server_url defined above MUST be using https, DERP requires TLS to be in place
-    enabled: false
+    enabled: true
 
     # Region ID to use for the embedded DERP server.
     # The local DERP prevails if the region ID collides with other region ID coming from
@@ -103,14 +103,13 @@ derp:
     # If you enable the DERP server and set this to false, it is required to add the DERP server to the DERP map using DERP.paths
     automatically_add_embedded_derp_region: true
 
-
     # it is possible to optionally add the public IPv4 and IPv6 address to the Derp-Map using:
-    ipv4: 198.51.100.1
-    ipv6: 2001:db8::1
+    # ipv4: 198.51.100.1
+    # ipv6: 2001:db8::1
 
   # List of externally available DERP maps encoded in JSON
-  urls:
-   - https://controlplane.tailscale.com/derpmap/default
+  # Set to empty list to disable Tailscale's built-in DERP servers
+  urls: []
 
   # Locally available DERP map files encoded in YAML
   #

--- a/go.mod
+++ b/go.mod
@@ -148,7 +148,7 @@ replace (
 	github.com/mvt-project/androidqf_ward => github.com/BARGHEST-ngo/androidqf_mesh v0.1.0
 	github.com/tailscale/wireguard-go v0.0.0-20250716170648-1d0488a3d7da => github.com/BARGHEST-ngo/amnezia-wireguard-go v0.1.1-alpha.1.0.20260217195927-fee73f569c4b
 	gvisor.dev/gvisor => gvisor.dev/gvisor v0.0.0-20250205023644-9414b50a5633
-	tailscale.com v1.94.1 => github.com/BARGHEST-ngo/mesh-tailscale v1.94.1-0.20260304180408-aa61c1758b45
+	tailscale.com v1.94.1 => github.com/BARGHEST-ngo/mesh-tailscale v1.94.1-0.20260327152222-09919c9dcffc
 )
 
 tool (

--- a/go.mod
+++ b/go.mod
@@ -148,7 +148,7 @@ replace (
 	github.com/mvt-project/androidqf_ward => github.com/BARGHEST-ngo/androidqf_mesh v0.1.0
 	github.com/tailscale/wireguard-go v0.0.0-20250716170648-1d0488a3d7da => github.com/BARGHEST-ngo/amnezia-wireguard-go v0.1.1-alpha.1.0.20260217195927-fee73f569c4b
 	gvisor.dev/gvisor => gvisor.dev/gvisor v0.0.0-20250205023644-9414b50a5633
-	tailscale.com v1.94.1 => github.com/BARGHEST-ngo/mesh-tailscale v1.94.1-0.20260327152222-09919c9dcffc
+	tailscale.com v1.94.1 => github.com/BARGHEST-ngo/mesh-tailscale v1.94.1-0.20260327174627-d9a5efd24f3f
 )
 
 tool (

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/BARGHEST-ngo/amnezia-wireguard-go v0.1.1-alpha.1.0.20260217195927-fee
 github.com/BARGHEST-ngo/amnezia-wireguard-go v0.1.1-alpha.1.0.20260217195927-fee73f569c4b/go.mod h1:Zls3lR6b2x7Dktrhlrq5SJm9ChkJsy53pn95oiRGAKc=
 github.com/BARGHEST-ngo/androidqf_mesh v0.1.0 h1:8rc2EYQ7H1CndPQjjZg3uY6r3anzqaELIrntHW+mXUk=
 github.com/BARGHEST-ngo/androidqf_mesh v0.1.0/go.mod h1:B1mVzR2BxtB6BpsFclmt6Y+3878Gj3VnSdlQem85n9E=
-github.com/BARGHEST-ngo/mesh-tailscale v1.94.1-0.20260304180408-aa61c1758b45 h1:6e+/t5FImySDulqm/vYBucPJ8d2T4yje6RoX/NDFU90=
-github.com/BARGHEST-ngo/mesh-tailscale v1.94.1-0.20260304180408-aa61c1758b45/go.mod h1:qSyXy39S0vqhg9/RKf0gpY8RjapUhWVMFDHCfL/cZnc=
+github.com/BARGHEST-ngo/mesh-tailscale v1.94.1-0.20260327152222-09919c9dcffc h1:NCEJU1FyoBJFjxXKcMm4NQ/SG8ApMJo1fmAPeTklTR0=
+github.com/BARGHEST-ngo/mesh-tailscale v1.94.1-0.20260327152222-09919c9dcffc/go.mod h1:qSyXy39S0vqhg9/RKf0gpY8RjapUhWVMFDHCfL/cZnc=
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/akutz/memconn v0.1.0 h1:NawI0TORU4hcOMsMr11g7vwlCdkYeLKXBcxWu2W/P8A=

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/BARGHEST-ngo/amnezia-wireguard-go v0.1.1-alpha.1.0.20260217195927-fee
 github.com/BARGHEST-ngo/amnezia-wireguard-go v0.1.1-alpha.1.0.20260217195927-fee73f569c4b/go.mod h1:Zls3lR6b2x7Dktrhlrq5SJm9ChkJsy53pn95oiRGAKc=
 github.com/BARGHEST-ngo/androidqf_mesh v0.1.0 h1:8rc2EYQ7H1CndPQjjZg3uY6r3anzqaELIrntHW+mXUk=
 github.com/BARGHEST-ngo/androidqf_mesh v0.1.0/go.mod h1:B1mVzR2BxtB6BpsFclmt6Y+3878Gj3VnSdlQem85n9E=
-github.com/BARGHEST-ngo/mesh-tailscale v1.94.1-0.20260327152222-09919c9dcffc h1:NCEJU1FyoBJFjxXKcMm4NQ/SG8ApMJo1fmAPeTklTR0=
-github.com/BARGHEST-ngo/mesh-tailscale v1.94.1-0.20260327152222-09919c9dcffc/go.mod h1:qSyXy39S0vqhg9/RKf0gpY8RjapUhWVMFDHCfL/cZnc=
+github.com/BARGHEST-ngo/mesh-tailscale v1.94.1-0.20260327174627-d9a5efd24f3f h1:hkxIyjPZWGalSZXf+B3YylrafxFaHg6hWMv7FAucPOM=
+github.com/BARGHEST-ngo/mesh-tailscale v1.94.1-0.20260327174627-d9a5efd24f3f/go.mod h1:qSyXy39S0vqhg9/RKf0gpY8RjapUhWVMFDHCfL/cZnc=
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/akutz/memconn v0.1.0 h1:NawI0TORU4hcOMsMr11g7vwlCdkYeLKXBcxWu2W/P8A=


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                
                                              
Prevents MESH clients from contacting Tailscale-controlled servers using Tailscale's built-in `ts_omit_*` build tags, plus hostname/config changes in the build pipeline.                                                                          
   
### Phone-home vectors eliminated                                                                                                                                                                                                                                                         
                                            
| Vector | Solution |
|--------|----------|
| Log uploads (`log.tailscale.com`) | `ts_omit_logtail` build tag |
| Network flow logging | `ts_omit_netlog` build tag |
| Captive portal probes | `ts_omit_captiveportal` build tag |                                                                                                                                                                                                                             
| Client auto-update (`pkgs.tailscale.com`) | `ts_omit_clientupdate` build tag |
| User metrics | `ts_omit_usermetrics` build tag |                                                                                                                                                                                                                                        
| Cloud detection (AWS/GCP/Azure metadata) | `ts_omit_cloud` build tag |
| DNS fallback bootstrap (Tailscale DERP IPs) | Replaced with empty set |                                                                                                                                                                                                                 
| DERP relay map | Headscale: `urls: []` + embedded DERP server |                                                                                                                                                                                                                         
| Hardcoded hostnames | `{log,controlplane,login}.tailscale.com` replaced with `*.example.com` |
                                                                                                                                                                                                                                                                                            
## Changes                                 
                                                                                                                                                                                                                                                                                            
- **`android-client/Makefile`** — `ts_omit_*` build tags passed to `gomobile bind`                                                                                                                                                                                                      
- **`analyst/src/cmd/generator/main.go`** — Extract from verified zip instead of module cache for improved supply chain security; hostname replacement (comment-aware via `go/parser` to reduce fork drift from upstream); empty DNS fallback servers
- **`control-plane/headscale/config.example.yaml`** — Enable embedded DERP, disable Tailscale DERP map URL                                                                                                                                                                                
- **`tailscale` submodule** — Updated fork ref with hostname replacements                                                                                                                                                                                                                 

## Breaking changes

- [x] No breaking changes
- [ ] Breaking change, migration, or operator-visible behavior change is described below

## Testing

- [x] Relevant automated tests were added/updated or not needed
- [ ] Relevant local checks were run
- [ ] CI checks passed, or failures are explained below

## Manual testing

> Integration tests and end-to-end functional tests are not fully implemented yet. Complete the applicable items below.

- [ ] Manual testing not needed (docs/comment-only change)
- [x] Core MESH flow verified where relevant (control plane, enrollment, connectivity, forensics, ADB pairing)
- [x] Android client flow verified where relevant (install/upgrade, connect/disconnect, permissions/background behavior)
- [ ] CLI / analyst tooling verified where relevant (affected `meshcli` commands, flags, output, error paths)
- [ ] Cross-platform / backward-compatibility checks completed where relevant

## Security considerations

- [ ] Auth, ACL, network exposure, and transport-security implications were reviewed
- [x] No secrets, keys, tokens, private certs, or sensitive data were added to the repo, logs, screenshots, or PR text
- [ ] New or updated dependencies were reviewed for necessity and known risk/vulnerabilities
- [ ] Input validation, error handling, and logs do not leak sensitive information
- [ ] Civil society / high-risk environment and F-Droid impacts were reviewed where applicable
- [ ] If security-sensitive, details are being handled per `SECURITY.md` rather than in public discussion

**Security notes:**

## Deployment

- [ ] CI/CD impact was verified
- [ ] Deployment, config, env var, secret, packaging, or release impact is documented

**Notes:**

## Documentation

- [x] No documentation updates needed
- [ ] README / docs updated
- [ ] User, analyst, or operator-facing changes documented

## Reviewer guidance

We should test headscale's embedded DERP server to ensure that functions when UDP is blocked