### PR TITLE
Feature/cleanup

### DIFF
--- a/analyst/entrypoint.sh
+++ b/analyst/entrypoint.sh
@@ -10,7 +10,8 @@ if [ -z "${LOGIN_URL}" ] || [ -z "${AUTH_KEY}" ]; then
 fi
 
 HOSTNAME_LEN=$(( (RANDOM % 10) + 6 ))
-RANDOM_HOSTNAME=$(tr -dc 'a-z0-9' < /dev/urandom | head -c "${HOSTNAME_LEN}")
+RANDOM_HOSTNAME=$(LC_ALL=C head -c 512 /dev/urandom | tr -dc 'a-z0-9')
+RANDOM_HOSTNAME="${RANDOM_HOSTNAME:0:$HOSTNAME_LEN}"
 
 /usr/bin/mesh \
     --statedir="${MESH_STATE_DIR}" \

--- a/analyst/src/cli/cleanup.go
+++ b/analyst/src/cli/cleanup.go
@@ -1,0 +1,80 @@
+// Copyright (c) BARGHEST
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package cli
+
+import (
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/mvt-project/androidqf_ward/adb"
+	"github.com/peterbourgon/ff/v3/ffcli"
+)
+
+var adbcleanArgs struct {
+	serial string
+}
+
+var adbcleanupCmd = &ffcli.Command{
+	Name:       "adbclean",
+	ShortUsage: "meshcli adbclean [flags]",
+	ShortHelp:  "Clears as much logging as possible from the session",
+	LongHelp: `In situations where you want to clean up after a session (for removing traces of forensics in case of seizure), adbclean will clear the logcat ring buffers and reset shell-accessible telemetry counters. [IMPORTANT] This should only be used AFTER a forensics backup. If used before, you will tamper with evidence. This is best-effort scrub of shell-accessible state only. Paired ADB key, wireless debugging history, and any root-only logs (tombstones, dropbox, pstore) are NOT removed and remain recoverable by a forensic examiner — only factory reset clears the paired-keys store. If seizure is anticipated, factory reset is the only reliable option; adbclean reduces the volume of recent telemetry but does not sanitize the device.
+
+Examples:
+  meshcli adbclean -serial devicename
+
+`,
+	FlagSet: (func() *flag.FlagSet {
+		fs := newFlagSet("adbclean")
+		fs.StringVar(&adbcleanArgs.serial, "serial", "", "Device serial number")
+		return fs
+	})(),
+	Exec: runcleanCmd,
+}
+
+func runcleanCmd(ctx context.Context, args []string) error {
+	adbClient, err := adb.New()
+	if err != nil {
+		return fmt.Errorf("impossible to initialize ADB: %v", err)
+	}
+	adb.Client = adbClient
+	if adbcleanArgs.serial != "" {
+		adb.Client.Serial = adbcleanArgs.serial
+	}
+
+	printf("Resetting battery stats history\n")
+	out, err := adb.Client.Shell("dumpsys", "batterystats", "--reset")
+	if err != nil {
+		printf("failed to reset batterystats (continuing): %v\n", err)
+	} else {
+		printf("batterystats reset: %s\n", out)
+	}
+
+	printf("Clearing process stats\n")
+	out, err = adb.Client.Shell("dumpsys", "procstats", "--clear")
+	if err != nil {
+		printf("failed to clear procstats (continuing): %v\n", err)
+	} else {
+		printf("procstats cleared: %s\n", out)
+	}
+
+	printf("Clearing statsd puller cache\n")
+	out, err = adb.Client.Shell("cmd", "stats", "clear-puller-cache")
+	if err != nil {
+		printf("failed to clear statsd puller cache (continuing): %v\n", err)
+	} else {
+		printf("statsd puller cache cleared: %s\n", out)
+	}
+
+	printf("Clearing logcat ring buffers\n")
+	out, err = adb.Client.Shell("logcat", "-b", "all", "-c")
+	if err != nil {
+		return fmt.Errorf("failed to run `adb shell logcat -b all -c`: %v", err)
+	}
+	printf("logcat cleared: %s\n", out)
+
+	printf("adbclean complete. Root-only artifacts remain — see --help.\n")
+	return nil
+}

--- a/analyst/src/cmd/generator/main.go
+++ b/analyst/src/cmd/generator/main.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"io"
@@ -215,6 +216,15 @@ func main() {
 		log.Fatalf("failed to replace Tailscale hostnames: %v", err)
 	}
 
+	log.Println("Rebranding Tailscale references in CLI help text...")
+	helpReplacements := map[string]string{
+		"Tailscale":  "MESH",
+		"tailscale ": "meshcli ",
+	}
+	if err := rewriteHelpStrings(tailscaleCliDir, helpReplacements); err != nil {
+		log.Fatalf("failed to rewrite help strings: %v", err)
+	}
+
 	// Run go mod tidy in the build directory
 	log.Println("Running go mod tidy...")
 	cmd = exec.Command("go", "mod", "tidy")
@@ -350,4 +360,93 @@ func extractZipFile(f *zip.File, destPath string) error {
 	}
 
 	return nil
+}
+
+// rewriteHelpStrings applies substring replacements to the *contents* of
+// string literals assigned to ShortHelp, LongHelp, or ShortUsage fields in
+// Go source files under dir. The replacement is scoped to those three
+// field names so that import paths, code identifiers, and unrelated strings
+// (e.g. "tailscale.com/...", "tailscaled") are not touched.
+func rewriteHelpStrings(dir string, replacements map[string]string) error {
+	helpFields := map[string]bool{
+		"ShortHelp":  true,
+		"LongHelp":   true,
+		"ShortUsage": true,
+	}
+
+	type edit struct {
+		start, end int
+		repl       string
+	}
+
+	return filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(d.Name(), ".go") || strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", path, err)
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, src, parser.ParseComments)
+		if err != nil {
+			return fmt.Errorf("parsing %s: %w", path, err)
+		}
+
+		var edits []edit
+		ast.Inspect(f, func(n ast.Node) bool {
+			kv, ok := n.(*ast.KeyValueExpr)
+			if !ok {
+				return true
+			}
+			id, ok := kv.Key.(*ast.Ident)
+			if !ok || !helpFields[id.Name] {
+				return true
+			}
+			ast.Inspect(kv.Value, func(x ast.Node) bool {
+				lit, ok := x.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				start := fset.Position(lit.Pos()).Offset
+				end := fset.Position(lit.End()).Offset
+				original := string(src[start:end])
+				if len(original) < 2 {
+					return true
+				}
+				quote := original[0]
+				inner := original[1 : len(original)-1]
+				replaced := inner
+				for old, new_ := range replacements {
+					replaced = strings.ReplaceAll(replaced, old, new_)
+				}
+				if replaced != inner {
+					edits = append(edits, edit{start, end, string(quote) + replaced + string(quote)})
+				}
+				return true
+			})
+			return true
+		})
+
+		if len(edits) == 0 {
+			return nil
+		}
+		sort.Slice(edits, func(i, j int) bool { return edits[i].start < edits[j].start })
+		var buf bytes.Buffer
+		prev := 0
+		for _, e := range edits {
+			buf.Write(src[prev:e.start])
+			buf.WriteString(e.repl)
+			prev = e.end
+		}
+		buf.Write(src[prev:])
+		if err := os.WriteFile(path, buf.Bytes(), 0644); err != nil {
+			return fmt.Errorf("writing %s: %w", path, err)
+		}
+		log.Printf("Rebranded help strings in %s", path)
+		return nil
+	})
 }

--- a/analyst/src/patches/bugreport.go.patch
+++ b/analyst/src/patches/bugreport.go.patch
@@ -1,0 +1,14 @@
+diff --git a/cmd/tailscale/cli/bugreport.go b/cmd/tailscale/cli/bugreport.go
+--- a/cmd/tailscale/cli/bugreport.go
++++ b/cmd/tailscale/cli/bugreport.go
+@@ -16,8 +16,8 @@
+ var bugReportCmd = &ffcli.Command{
+-	Name:       "bugreport",
++	Name:       "meshbugreport",
+ 	Exec:       runBugReport,
+ 	ShortHelp:  "Print a shareable identifier to help diagnose issues",
+-	ShortUsage: "tailscale bugreport [note]",
++	ShortUsage: "meshcli meshbugreport [note]",
+ 	FlagSet: (func() *flag.FlagSet {
+ 		fs := newFlagSet("bugreport")
+ 		fs.BoolVar(&bugReportArgs.diagnose, "diagnose", false, "run additional in-depth checks")

--- a/analyst/src/patches/cli.go.patch
+++ b/analyst/src/patches/cli.go.patch
@@ -5,7 +5,7 @@ index 5ebc23a5b..862c1b1e6 100644
 @@ -20,6 +20,7 @@
  	"text/tabwriter"
  	"time"
- 
+
 +	"github.com/i582/cfmt/cmd/cfmt"
  	"github.com/mattn/go-colorable"
  	"github.com/mattn/go-isatty"
@@ -13,7 +13,7 @@ index 5ebc23a5b..862c1b1e6 100644
 @@ -120,6 +121,12 @@ func Run(args []string) (err error) {
  		})
  	})
- 
+
 +	cfmt.Print(`
 +	{{[ 𝗠𝗘𝗦𝗛 ]}}::blue
 +	{{[ 𝐀𝐍𝐀𝐋𝐘𝐒𝐓 𝐂𝐋𝐈𝐄𝐍𝐓 ]}}::blue
@@ -23,8 +23,8 @@ index 5ebc23a5b..862c1b1e6 100644
  	rootCmd := newRootCmd()
  	if err := rootCmd.Parse(args); err != nil {
  		if errors.Is(err, flag.ErrHelp) {
-@@ -233,16 +240,19 @@ func newRootCmd() *ffcli.Command {
- 
+@@ -233,51 +240,46 @@ func newRootCmd() *ffcli.Command {
+
  	var rootCmd *ffcli.Command
  	rootCmd = &ffcli.Command{
 -		Name:       "tailscale",
@@ -36,7 +36,7 @@ index 5ebc23a5b..862c1b1e6 100644
  		LongHelp: strings.TrimSpace(`
 -For help on subcommands, add --help after: "tailscale status --help".
 +For help on subcommands, add --help after: "meshcli status --help".
- 
+
  This CLI is still under active development. Commands and flags will
  change in the future.
  `),
@@ -44,10 +44,15 @@ index 5ebc23a5b..862c1b1e6 100644
 +			adbpairCmd,
 +			adbcollectCmd,
 +			adbdisableCmd,
++			adbcleanupCmd,
  			upCmd,
  			downCmd,
  			setCmd,
-@@ -254,7 +264,7 @@ func newRootCmd() *ffcli.Command {
+ 			loginCmd,
+ 			logoutCmd,
+ 			switchCmd,
+ 			configureCmd(),
+-			nilOrCall(sysPolicyCmd),
  			netcheckCmd,
  			ipCmd,
  			dnsCmd,
@@ -56,3 +61,26 @@ index 5ebc23a5b..862c1b1e6 100644
  			metricsCmd,
  			pingCmd,
  			ncCmd,
+ 			sshCmd,
+ 			nilOrCall(maybeFunnelCmd),
+ 			nilOrCall(maybeServeCmd),
+ 			versionCmd,
+-			nilOrCall(maybeWebCmd),
+ 			nilOrCall(fileCmd),
+ 			bugReportCmd,
+ 			nilOrCall(maybeCertCmd),
+ 			nilOrCall(maybeNetlockCmd),
+-			licensesCmd,
+ 			exitNodeCmd(),
+-			updateCmd,
+ 			whoisCmd,
+-			debugCmd(),
+ 			nilOrCall(maybeDriveCmd),
+-			idTokenCmd,
+-			configureHostCmd(),
+-			systrayCmd,
+-			appcRoutesCmd,
+ 		),
+ 		FlagSet: rootfs,
+ 		Exec: func(ctx context.Context, args []string) error {
+ 			if *jsonDocs {


### PR DESCRIPTION
- Add meshcli adbclean — best-effort ADB session scrub (clears logcat ring buffers + resets dumpsys/statsd counters).
  Honest help text about root-only artifacts that remain. Closes #60.
- Trim upstream Tailscale subcommands outside forensics scope 
- Rebrand Tailscale -- MESH in CLI help text via AST-scoped generator pass 
- Fix SIGPIPE in entrypoint's random hostname generation-- regression from #60's hostname commit made the analyst container exit 141 on startup.