### PR TITLE
Document containerization and ephemeral build system

### DIFF
--- a/docs/reference/build-deploy/build-orchestration.md
+++ b/docs/reference/build-deploy/build-orchestration.md
@@ -1,0 +1,157 @@
+# Build orchestration
+
+MESH uses [go-task](https://taskfile.dev) for build orchestration and task running. Two Taskfiles split responsibilities:
+
+- `Taskfile.yml` is user-facing (deploy-time).
+- `Taskfile.dev.yml` is developer-facing (build-time).
+
+Both auto-load `.env` and run silently by default.
+
+## Why Task?
+
+Three constraints shaped the choice:
+
+- **Interactive prompts that work cross-platform.** The setup flow asks for the control plane type, domain, and auth key, then writes them to `.env`. Task's `prompt:` and `requires.vars.enum:` directives make this declarative. `make` would need a custom shell wrapper per platform.
+- **Embedded platform-specific tasks.** Several tasks branch on OS (sed vs PowerShell, Linux sed vs macOS sed). Task exposes `platforms: [linux, darwin, windows]` on individual commands, so one Taskfile serves all three.
+- **Dotenv loading.** `dotenv: [.env]` means every task sees configuration variables without sourcing scripts.
+
+## `Taskfile.yml`: user-facing tasks
+
+Path: `Taskfile.yml`. Default invocation target. All user-facing tasks live here.
+
+### Task reference
+
+| Task | Purpose | Depends on |
+|---|---|---|
+| `build` | `docker compose build` | |
+| `controlPlane` | `docker compose up -d headscale ui` | `configureControlPlane` |
+| `down` | `docker compose down` | |
+| `apikey` | Calls `headscale apikeys create --expiration 3h` inside the running container. Prints a help message if the container isn't running locally. | |
+| `analyst` | Brings up the analyst service and opens an interactive bash shell via `docker compose exec analyst /bin/bash`. | `configureAnalyst` |
+| `setAuthKey` | Stops the analyst, removes its volume, and re-prompts for a new `AUTH_KEY`. Use when rotating keys or starting a fresh session. | |
+
+### The configuration flow
+
+`configureControlPlane` and `configureAnalyst` are high-level tasks that run the interactive setup prompts. Each prompt task is guarded by an `if:` so it only runs when the relevant `.env` variable is empty. Rerunning `task controlPlane` on a configured checkout skips the prompts.
+
+```text
+controlPlane
+  └── configureControlPlane
+        ├── controlPlaneType      (prompts Ephemeral vs Persistent)
+        ├── controlPlaneDomain    (prompts domain name)
+        ├── headscaleConfig       (sed-substitutes config.example.yaml if config.yaml missing)
+        └── confirmDotEnv         (cat .env, prompt "looks correct?")
+```
+
+### Headscale config templating
+
+`headscaleConfig` (internal) substitutes `CONTROL_PLANE_DOMAIN` in `config.example.yaml` and writes `config.yaml`, but only if the latter doesn't exist:
+
+```yaml
+- task: headscaleConfig
+  if: '[ ! -f control-plane/headscale/config.yaml ]'
+```
+
+The task declares `sources:` and `generates:` so Task skips it if the source hasn't changed since the generate target's mtime. On Windows, a PowerShell `-replace` command does the same thing.
+
+### Key rotation: `setAuthKey`
+
+```yaml
+cmds:
+  - docker compose down analyst && docker volume rm $(docker compose volumes -q | grep analyst-data) || true
+  - <prompt>
+  - task: promptAnalystAuthKey
+```
+
+Stopping the analyst and deleting its volume before asking for the new key ensures the container can't come up with stale state between the prompt and the restart.
+
+---
+
+## `Taskfile.dev.yml`: developer-facing tasks
+
+Path: `Taskfile.dev.yml`. Invoked via `task -t Taskfile.dev.yml <task>`. Holds every task that a contributor runs and an end-user should not.
+
+### Task reference
+
+| Task | What it does |
+|---|---|
+| `tidy` | `go mod tidy`. Kept separate because it mutates `go.sum` and affects reproducibility. |
+| `generate` | `go generate ./...`. Depends on `submoduleInit`. |
+| `docs` | `mkdocs build`. |
+| `serveDocs` | `mkdocs serve` with live reload on `:8000`. |
+| `buildAnalyst` | Runs `analyst/src/build.sh`. Produces `analyst/mesh`. Depends on `submoduleInit`. |
+| `buildAndroid` | `make -C android-client apk`. |
+| `buildAndroidRelease` | `make -C android-client release-apk`. Unsigned. |
+| `buildAndroidSigned` | `make -C android-client release-apk-signed`. Requires `JKS_PATH`, `JKS_PASSWORD`, `JKS_ALIAS` env vars. |
+| `clean` | `rm -f analyst/mesh` and `make -C android-client clean`. |
+| `tagRelease` | Calls `scripts/tag-release.sh $VERSION`. See [CI and release](ci-and-release.md#release-script). |
+| `fdroidInit` | Initialise a local F-Droid repo for reproducibility testing. |
+| `fdroidBuild` | `cd fdroid && fdroid build -v -l com.barghest.mesh`. |
+| `pinGithubActions` | `go tool github.com/stacklok/frizbee actions .github/workflows`. |
+
+---
+
+## Analyst build script
+
+Path: `analyst/src/build.sh`. Called by the Dockerfile (stage 1) and by `task buildAnalyst`. Single source of truth for the mesh binary build.
+
+### What it does
+
+1. Locates the Go module directory via `go env GOMOD`.
+2. Assembles build tags, always adding `ts_omit_logtail` (omits Tailscale telemetry) and any extra tags supplied through `$TAGS`.
+3. `cd` into `$GO_MOD_DIR/tailscale` (the submodule).
+4. Runs:
+
+    ```bash
+    go build -tags "$tags" -trimpath -o "$GO_MOD_DIR/analyst/mesh" ./cmd/tailscaled
+    ```
+
+### Why a separate script rather than inline in the Dockerfile?
+
+Two reasons:
+
+- `task buildAnalyst` runs it for local dev without Docker. Contributors iterating on CLI changes rebuild in seconds instead of rebuilding the whole container.
+- Build flags live in one place. A change to build tags updates both the container image and local dev builds without drift.
+
+---
+
+## Development container
+
+Path: `.devcontainer/Dockerfile`, `.devcontainer/devcontainer.json`. Defines an ephemeral development environment compatible with VS Code's Remote Containers and GitHub Codespaces.
+
+### What the image installs
+
+The image is built from a devcontainers Debian base image. It installs:
+
+- Microsoft OpenJDK, Go, Node.js, and pnpm.
+- The Android command-line tools and the SDK components needed for Android builds.
+- Task CLI.
+
+Java and the Android command-line tools are checksum-verified in the Dockerfile. Go is version-pinned via the `GO_VERSION` build arg. Android SDK licenses are auto-accepted with `yes | sdkmanager --licenses`.
+
+### `devcontainer.json` features
+
+- Docker-outside-of-Docker so `docker compose` inside the devcontainer drives the host Docker daemon.
+- MkDocs tooling so `task docs` and `task serveDocs` work without extra setup.
+- Gradle on `PATH` for Android builds.
+- Python plus `fdroidserver` for local F-Droid reproducibility work.
+
+### Mounts and environment
+
+- Binds `~/.android` from the host to `/root/.android` to persist the Android debug keystore across rebuilds.
+- Sets `LOCAL_WORKSPACE_FOLDER=${localWorkspaceFolder}` so bind mounts in `compose.yml` resolve to the host's repo path, not a path inside the devcontainer.
+- Forwards port `80` so the UI is reachable from the host browser.
+
+---
+
+## Dependencies and assumptions
+
+- **A `task` release with `prompt:` and `requires.vars.enum:` support**.
+- **`go` on PATH** for `task tidy`, `task generate`, `task buildAnalyst`. The CI workflow sets this up via `actions/setup-go` reading `go-version-file: go.mod`.
+- **`git submodule` initialised** before running any build task. `submoduleInit` handles this but requires network access on first run.
+- **F-Droid work** requires `fdroidserver`, which requires Python, gradle, JDK, and the Android SDK. The devcontainer has all of this.
+- **Signed releases** require `JKS_PATH`, `JKS_PASSWORD`, and `JKS_ALIAS` environment variables and an existing `.jks` keystore. `task buildAndroidSigned` fails if these are missing.
+
+---
+
+← [Runtime stack](runtime-stack.md) | [CI and release](ci-and-release.md) →

--- a/docs/reference/build-deploy/ci-and-release.md
+++ b/docs/reference/build-deploy/ci-and-release.md
@@ -1,0 +1,109 @@
+# CI and release
+
+Every MESH release job runs on a freshly provisioned GitHub-hosted runner. This page documents the Android release flow, its guarantees, and its inputs. Exact action SHAs, cache keys, and toolchain pins live in the workflow and script files that enforce them.
+
+## Release workflow
+
+The documented release path has two entry points:
+
+- Tag pushes matching `v*` for real releases.
+- `workflow_dispatch` for maintainers who need to rebuild a specific version string manually.
+
+Pull requests touching the Android build inputs also exercise the same build logic in unsigned mode so reproducibility problems show up before release.
+
+## `android-release.yml`
+
+Path: `.github/workflows/android-release.yml`. Four jobs cooperate here: `build-release`, `verify-reproducibility`, `create-release`, and `provenance`.
+
+### Triggers
+
+- Tag pushes matching `v*` run the full release path.
+- Pull requests touching the Android build inputs run an unsigned build plus reproducibility verification.
+- `workflow_dispatch` lets a maintainer rebuild a specific version string without moving tags.
+
+### Job 1: `build-release`
+
+Runs on `ubuntu-latest` with `android-client` as the working directory. It is the primary build job:
+
+1. Checks out the repo and sets up Go from `go.mod`.
+2. Installs the Java and Android toolchain pinned in the workflow.
+3. On tag/manual release runs, decodes the signing keystore from secrets and builds the signed APK. On PRs, builds the unsigned APK only.
+4. Hashes the unsigned APK and exposes that hash as a job output for the reproducibility job.
+5. Derives a version string from the tag, manual input, or PR number. Non-PR runs then rename the artifact, compute the provenance subject hash, and upload the APK artifact.
+
+The outputs are the unsigned APK hash for reproducibility verification and the base64-encoded release artifact hash for the provenance job.
+
+### Job 2: `verify-reproducibility`
+
+Runs after `build-release`, on a separate `ubuntu-latest` runner. It installs the same pinned toolchain, rebuilds the unsigned APK, and compares its SHA-256 hash to the one exported by `build-release`.
+
+**What this proves:** the unsigned APK is reproducible across two clean runners. If the hashes differ, the release path introduced nondeterminism somewhere in source generation, filesystem ordering, timestamps, or toolchain behavior.
+
+**Why unsigned?** The unsigned APK is the deterministic artifact. Signing adds a signature block and related metadata, so the signed APK is expected to differ even when the unsigned payload is reproducible.
+
+### Job 3: `create-release`
+
+Runs only on `push` of a tag. Downloads the APK artifact from `build-release`, creates a GitHub Release with `generate_release_notes: true`, and attaches the APK.
+
+### Job 4: `provenance`
+
+Also runs only on tag push. Calls the reusable workflow:
+
+```yaml
+uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@<pinned-release-ref>
+with:
+  base64-subjects: ${{ needs.build-release.outputs.hashes }}
+  upload-assets: true
+```
+
+This produces SLSA Level 3 provenance and attaches it to the GitHub Release alongside the APK. It runs in a separate reusable workflow, which reduces the chance that the primary build job can tamper with provenance generation. The repo's action-pinning rule intentionally excludes this reusable workflow because SLSA verification expects a release-style ref. See [Build and release safeguards](#build-and-release-safeguards) below.
+
+### Secrets
+
+- `KEYSTORE_BASE64` becomes a temporary `mesh-release.jks` file for the signing step.
+- `KEYSTORE_PASSWORD` and `KEYSTORE_ALIAS` are passed as environment variables to Gradle.
+- The keystore file is removed unconditionally before job exit.
+
+None of the secret values are written intentionally to logs, and GitHub masks them automatically.
+
+## Release script
+
+Path: `scripts/tag-release.sh`. Invoked via `task -t Taskfile.dev.yml tagRelease VERSION=<semver>`.
+
+### Preconditions
+
+The script fails unless all of the following are true:
+
+1. The requested version is strict semver.
+2. Required tooling is installed, including `go tool yq`.
+3. The working tree is clean.
+4. The current branch is `main`.
+5. The `tailscale/` submodule is clean and matches the parent repo's recorded SHA.
+6. Neither the main-repo tag nor the submodule tag already exists locally.
+7. If remote checks are enabled, local `main` matches `origin/main` and the tag does not already exist on the remote.
+
+### Version bump
+
+The script intentionally modifies only three files:
+
+- `android-client/android/build.gradle` for the Android `versionCode`.
+- `android-client/barghest.version` for the human-readable version fields.
+- `android-client/fdroid/com.barghest.mesh.yml` for the new F-Droid build entry and current-version pointers.
+
+### Commit and tags
+
+The script creates one release-preparation commit plus two annotated tags: the main repo tag (`vX.Y.Z`) and the tailscale submodule tag (`mesh-vX.Y.Z`).
+
+**Submodule tag prefix.** The submodule tag is `mesh-vX.Y.Z`, not `vX.Y.Z`. The tailscale submodule's remote is shared with upstream Tailscale, so the `mesh-` prefix prevents a tag collision.
+
+---
+
+## Build and release safeguards
+
+- **SLSA L3 provenance** on every Android release, generated on an isolated runner.
+- **Reproducibility verification** on every release and on PRs that modify Android build inputs.
+- **Pinned Java and Android toolchains** in both CI and the devcontainer, with exact values kept in the workflow/Dockerfile sources.
+
+---
+
+← [Build orchestration](build-orchestration.md) | [Troubleshooting](troubleshooting.md) →

--- a/docs/reference/build-deploy/index.md
+++ b/docs/reference/build-deploy/index.md
@@ -1,0 +1,52 @@
+# Build and deploy
+
+This section documents MESH's containerization strategy and its build and release pipelines. It's written for analysts, contributors, and anyone auditing the supply chain. For end-user setup, see the [Setup guide](../../setup/index.md).
+
+## What's in this section
+
+- **[Runtime stack](runtime-stack.md)**: the `compose.yml` stack and every `Dockerfile` that ships in the repo.
+- **[Build orchestration](build-orchestration.md)**: the Task-based build system (`Taskfile.yml`, `Taskfile.dev.yml`), the analyst build script, and the VS Code devcontainer.
+- **[CI and release](ci-and-release.md)**: the Android release workflow and `scripts/tag-release.sh`.
+- **[Build troubleshooting](troubleshooting.md)**: build and container-layer issues. For network, auth, and runtime problems, see [Reference Troubleshooting](../troubleshooting.md).
+
+## Key design decisions
+
+### 1. Docker Compose for the runtime, go-task for orchestration
+
+`compose.yml` defines three services (`headscale`, `ui`, `analyst`) and is invoked via `docker compose` directly. All orchestration lives in two Taskfiles rather than `make` or shell scripts. This includes interactive setup prompts, `.env` management, templated config generation, and release tagging. [go-task](https://taskfile.dev) is a better fit than `make` for this job: tasks are declarative, dependencies between them are explicit, and the built-in `prompt:` directive handles interactive setup nicely.
+
+### 2. Multi-stage Dockerfiles with pinned base images
+
+Every `Dockerfile` uses multi-stage builds and pins its base images in the source files that actually consume them. Build-time downloads such as the Android command-line tools are checksum-verified where the Dockerfiles fetch them.
+
+### 3. Ephemeral-first analyst container
+
+The analyst container generates a random hostname on every start. It accepts credentials only via `LOGIN_URL` and `AUTH_KEY` environment variables, and stores per-session state in a named Docker volume. Rotating the auth key with `task setAuthKey` stops the analyst and removes that volume before prompting for the new key. No long-lived identity is baked into the image.
+
+### 4. Reproducible Android releases
+
+The Android release pipeline rebuilds the unsigned APK on a second, isolated runner and fails the release if the SHA-256 hashes differ. SLSA Level 3 provenance is generated via the `slsa-github-generator` reusable workflow. Go comes from `go.mod`, and the Java/Android toolchain is pinned in the Dockerfiles and workflow files that install it.
+
+Reproducibility is a security benefit on its own. F-Droid has argued that VPN apps require an unusually high trust baseline that reproducible builds help establish. See F-Droid's [VPN trust requires Free Software](https://f-droid.org/en/2023/03/08/vpn-trust-requires-free-software.html) post.
+
+### 5. Supply-chain hardening
+
+- GitHub Actions are pinned to commit SHAs via [frizbee](https://github.com/stacklok/frizbee), refreshed on demand with `task pinGithubActions`.
+- Go vulnerability scanning (`govulncheck`) and linting (`golangci-lint`) run on pushes to `main` and on PRs that modify Go sources.
+- The tailscale submodule is tagged separately with a `mesh-v*` prefix to prevent collisions with upstream Tailscale tags in a shared remote.
+
+### 6. Config via `.env`, never committed
+
+All runtime configuration (`CONTROL_PLANE_DOMAIN`, `LOGIN_URL`, `AUTH_KEY`, `CORS_ORIGIN`, `NGINX_MODE`) is read from `.env` at the repo root. The file is created on first `task` run with `chmod 600`. There is no committed `.env.example`. Instead, the Taskfile prompts define the variables.
+
+## Assumptions
+
+- You have Docker Engine with the Compose V2 plugin (`docker compose`, not `docker-compose`).
+- You have the [go-task](https://taskfile.dev) CLI installed. Most tasks work without it via plain `docker compose`, but interactive setup does not.
+- You're on Linux, macOS, or WSL. Native Windows works for many tasks but is untested in CI.
+- For Android work: Go matching `go.mod`, plus the Java/Android toolchain declared in `.devcontainer/Dockerfile` and `.github/workflows/android-release.yml`. Or just use the [devcontainer](build-orchestration.md#development-container).
+- For release work: the `tailscale/` submodule is initialised. Clone with `git clone --recurse-submodules https://github.com/BARGHEST-ngo/MESH.git`, or on an existing clone run `git submodule update --init --recursive`.
+
+---
+
+**Next:** [Runtime stack](runtime-stack.md)

--- a/docs/reference/build-deploy/runtime-stack.md
+++ b/docs/reference/build-deploy/runtime-stack.md
@@ -1,0 +1,207 @@
+# Runtime stack
+
+This page documents `compose.yml` and every `Dockerfile` that is pulled into the runtime stack. The devcontainer (`.devcontainer/Dockerfile`) is covered separately in [Build orchestration](build-orchestration.md#development-container) because it is a build-time environment, not a runtime component.
+
+## Compose file
+
+Path: `compose.yml` (repo root).
+
+The Compose file defines three services that together form the control plane plus an analyst workstation. Services set `restart: unless-stopped` where the service is long-running, and rely on Compose defaults for networking (a single project-scoped bridge network, service-name DNS).
+
+```yaml
+services:
+  headscale:
+    image: docker.io/headscale/headscale:<pinned-tag>
+    # config, state volumes, tmpfs for /var/run/headscale
+
+  ui:
+    build: ./control-plane/mesh-ui
+    ports: ["127.0.0.1:80:80"]
+    depends_on: [headscale]
+
+  analyst:
+    build: { context: ., dockerfile: analyst/Dockerfile }
+    cap_add: [NET_ADMIN, NET_RAW]
+    devices: ["/dev/net/tun:/dev/net/tun"]
+```
+
+### Service: `headscale`
+
+Pulls the upstream Headscale image unchanged. MESH does not fork Headscale; the exact tag is pinned in `compose.yml`.
+
+Three mounts shape its state:
+
+- **`control-plane/headscale` to `/etc/headscale`** (bind mount). Holds `config.yaml` generated from `config.example.yaml` at first run. The path is expanded via `${LOCAL_WORKSPACE_FOLDER:-.}` so the devcontainer can bind-mount the host repo path rather than the path inside the container.
+- **`headscale-data` to `/var/lib/headscale`** (named volume). SQLite database, noise private key, optional DERP private key. Survives `docker compose down` but removable with `docker volume rm`.
+- **`/var/run/headscale`** (tmpfs). Unix socket and other runtime state that must not persist.
+
+Entrypoint is `headscale serve`. No host ports are published directly. Traffic reaches Headscale through the `ui` service's nginx proxy.
+
+### Service: `ui`
+
+Built from `control-plane/mesh-ui/` via the two-stage `Dockerfile` described below.
+
+**Environment variables:**
+
+- **`CORS_ORIGIN`** (default `*`). Substituted into the `Access-Control-Allow-Origin` response header.
+- **`NGINX_MODE`** (default `prod`). Switches the nginx config between `dev` (reverse-proxy all requests to Vite on `localhost:3000`) and `prod` (serve pre-built static files and fall through to `/index.html` for SPA routing).
+
+The entrypoint does not use the image's default. It replaces it with:
+
+```bash
+envsubst '$CORS_ORIGIN $NGINX_MODE' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && nginx -g 'daemon off;'
+```
+
+The bind-mounted `control-plane/nginx.conf` is treated as a template. Only `$CORS_ORIGIN` and `$NGINX_MODE` are substituted. Other nginx variables (such as `$http_upgrade` or `$uri`) survive because `envsubst` is given an explicit allowlist.
+
+nginx proxies the headscale API endpoints (`/api`, `/register`, `/key`, `/machine`, `/derp`, `/verify`, `/health`, `/ts2021`, `/swagger`) to `http://headscale:8080` and serves (or proxies to Vite) everything else. Long-lived connection timeouts are set to 24 hours for WebSocket support.
+
+Only port `80` is exposed, bound to `127.0.0.1`. A reverse proxy or tunnel is responsible for TLS termination and public exposure.
+
+### Service: `analyst`
+
+Built locally from `analyst/Dockerfile` with the repo root as build context, so Go source and the tailscale submodule are both available.
+
+**Capabilities and devices:** `NET_ADMIN` and `NET_RAW` are required for WireGuard/AmneziaWG tunnel creation. `/dev/net/tun` is passed through from the host, so the host kernel must expose it. IP forwarding is enabled per-namespace via `sysctls`, which lets the container act as a gateway between its interfaces without changing host-wide kernel settings.
+
+**Environment:**
+
+- **`LOGIN_URL`**: defaults to `https://${CONTROL_PLANE_DOMAIN}` if unset. Wires the analyst to whichever control plane the user configured.
+- **`AUTH_KEY`**: a Headscale pre-auth key. Required. No default.
+
+Both values are read from `.env`.
+
+**State:** the `analyst-data` named volume mounts at `/root/.tailscale`. Holds the daemon state and the two log files (`mesh.log`, `meshcli.log`). Removed by `task setAuthKey` when rotating the auth key.
+
+### Volumes
+
+Only two are declared:
+
+- `headscale-data`: Headscale's persistent state.
+- `analyst-data`: analyst daemon state.
+
+Both are project-scoped. Compose prefixes volume names with the project name (derived from the directory, lowercased). Typically `mesh_headscale-data`, but `mesh-fork_headscale-data` if you've cloned into `mesh-fork/`. List them with `docker volume ls`.
+
+---
+
+## `analyst/Dockerfile`
+
+Path: `analyst/Dockerfile`. Three stages. Final image: a slim Debian runtime with a JRE, Android command-line tooling, and the mesh daemon.
+
+### Stage 1: Go build stage
+
+Compiles the mesh daemon from the tailscale submodule.
+
+```dockerfile
+FROM golang:<pinned>-alpine AS build
+RUN apk add --no-cache git patch
+WORKDIR /usr/src/app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY analyst/src ./analyst/src
+RUN go generate ./...
+RUN ./analyst/src/build.sh
+```
+
+`go mod download` runs before the source copy so the layer is cacheable across code changes. `analyst/src/build.sh` is the single source of truth for the build command. It is called both here and from `task buildAnalyst`. See [Build orchestration](build-orchestration.md#analyst-build-script) for what it does.
+
+### Stage 2: Android SDK bootstrap stage
+
+Installs the Android SDK command-line tools in a throwaway stage, so the final image can `COPY --from=android-sdk` without having to install `wget`, `unzip`, or the JDK's build-time dependencies into the runtime.
+
+```dockerfile
+ARG ANDROID_TOOLS_VERSION=<pinned>
+ARG ANDROID_TOOLS_SUM=<vendored-sha256>
+# wget -> sha256sum --strict --check -> unzip -> sdkmanager --licenses -> sdkmanager "platform-tools"
+```
+
+The SHA256 of the command-line tools zip is checked strictly, and a mismatch fails the build immediately. The SDK is installed to `/usr/local/android-sdk` using the `cmdline-tools/latest` layout. Only `platform-tools` are installed here. That keeps the runtime image useful for device interaction without turning it into a full Android build environment; the heavier Android build toolchain stays in the devcontainer and CI.
+
+### Stage 3: Runtime stage
+
+Final layer. Installs only three packages: `iptables`, `iproute2`, `iputils-ping`.
+
+Copies in:
+
+- JRE from the android-sdk stage.
+- Android SDK from the android-sdk stage.
+- `/usr/src/app/analyst/mesh` from the build stage to `/usr/bin/mesh`.
+- `analyst/entrypoint.sh` to `/usr/bin/entrypoint.sh`.
+- `analyst/amneziawg.conf.example` to `/etc/mesh/amneziawg.conf.example`.
+
+### `.bashrc` welcome screen
+
+A multi-line `RUN printf ... >> /root/.bashrc` injects a `meshcli` alias and an interactive-shell-only welcome banner listing subcommands. The `if [[ $- == *i* ]]` guard ensures non-interactive invocations (such as `docker compose exec analyst bash -c '...'`) don't print the banner into piped output.
+
+### Entrypoint
+
+`analyst/entrypoint.sh` (bash, `set -eo pipefail`) is responsible for the ephemeral node behaviour:
+
+1. Fails fast if `LOGIN_URL` or `AUTH_KEY` is unset.
+2. Generates a random hostname of 6 to 15 `[a-z0-9]` characters via `/dev/urandom`.
+3. Launches the mesh daemon in the background with `--statedir=/root/.tailscale`, tee'd to `mesh.log`.
+4. Runs `mesh cli up` with the generated hostname, `--accept-dns=false`, and a 10-second timeout, tee'd to `meshcli.log`.
+5. `exec tail -f` on both log files so Compose keeps the container alive and `docker logs` shows daemon output.
+
+Because the hostname is regenerated on every container start, reconnects show up as new node names. Whether old entries disappear automatically depends on the control-plane configuration and the kind of pre-auth key in use. With ephemeral keys and the current Headscale config, stale entries age out after `ephemeral_node_inactivity_timeout`.
+
+---
+
+## `control-plane/mesh-ui/Dockerfile`
+
+Path: `control-plane/mesh-ui/Dockerfile`. Two stages.
+
+### Stage 1: `node:22-alpine` (build)
+
+```dockerfile
+FROM node:22-alpine AS build
+WORKDIR /app
+RUN npm install -g pnpm
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY . .
+RUN pnpm run build
+```
+
+`--frozen-lockfile` makes the build fail if `pnpm-lock.yaml` and `package.json` disagree, which catches accidental unversioned dep changes. `pnpm` is installed via `npm install -g` rather than via corepack or a feature flag.
+
+### Stage 2: `nginx:alpine`
+
+```dockerfile
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+```
+
+The image ships only the built SPA. The nginx config is bind-mounted by Compose (`control-plane/nginx.conf:/etc/nginx/nginx.conf.template`) and substituted at container start, so config changes apply without rebuilding the image.
+
+---
+
+## `control-plane/nginx.conf`
+
+### Location routing
+
+- `/(api|register|key|machine|derp|verify|health|ts2021|swagger)` proxies to `http://headscale:8080` (service-name DNS).
+- `/` in dev mode (if `$should_proxy` is set) proxies to `http://localhost:3000` (Vite).
+
+### Security headers
+
+Set on every response, always:
+
+- A Content-Security-Policy allowing `'self'`, inline styles and scripts, and unpkg.com for SwaggerUI scripts/styles.
+- `X-Content-Type-Options: nosniff`.
+- `X-Frame-Options: DENY`.
+- `X-XSS-Protection: 1; mode=block`.
+
+---
+
+## Dependencies and assumptions
+
+- **Docker Engine with Compose V2 support**. The stack expects the modern `docker compose` plugin rather than legacy `docker-compose`.
+- **Host kernel** must expose `/dev/net/tun`. On Linux this is standard. On a stripped-down kernel you'll need `modprobe tun`.
+- **Host networking** must allow inbound on the `ui` service's bound port (defaults to `127.0.0.1:80`). A reverse proxy or tunneling service terminates TLS.
+- **Workspace folder path**: `${LOCAL_WORKSPACE_FOLDER:-.}` is set by the devcontainer (`remoteEnv` in `devcontainer.json`) so bind mounts resolve to the host path, not the path inside the devcontainer. Outside the devcontainer, it falls back to the repo root directory.
+
+---
+
+← [Overview](index.md) | [Build orchestration](build-orchestration.md) →

--- a/docs/reference/build-deploy/troubleshooting.md
+++ b/docs/reference/build-deploy/troubleshooting.md
@@ -1,0 +1,364 @@
+# Build troubleshooting
+
+Build and container-specific issues. For runtime network, auth, and peer connectivity problems, see [Reference Troubleshooting](../troubleshooting.md).
+
+## Compose stack won't start
+
+### `docker compose build` fails pulling a base image
+
+**Symptoms:**
+
+- `ERROR: failed to pull image ...: manifest unknown` or similar during `task build`.
+
+**Causes:**
+
+- A pinned base image tag was removed from Docker Hub.
+- Docker Hub is rate-limiting.
+
+**Solutions:**
+
+1. **Confirm connectivity**
+
+    ```bash
+    docker pull <image-from-the-error>
+    ```
+
+2. **If rate-limited**: authenticate with `docker login`. The free tier raises the anonymous rate limit.
+3. **If the pinned image reference is actually gone**: update the relevant Dockerfile in a PR and review any related CI or devcontainer pins at the same time.
+
+### `analyst` container exits immediately
+
+**Symptoms:**
+
+- `docker compose up analyst` starts then stops.
+- `docker compose logs analyst` shows `Set the LOGIN_URL and AUTH_KEY environment variables in .env to run the MESH analyst client.`
+
+**Solutions:**
+
+1. Run `task analyst` (not `docker compose up analyst`). The Task wrapper prompts for missing values.
+2. Or edit `.env` directly. Set both `LOGIN_URL` and `AUTH_KEY`.
+
+### `analyst` container starts but tunnel doesn't come up
+
+**Symptoms:**
+
+- Logs show `tun device creation failed` or `operation not permitted`.
+
+**Causes:**
+
+- `/dev/net/tun` is not available on the host.
+- The container isn't getting `NET_ADMIN` or `NET_RAW`.
+- User namespace remapping (such as rootless Docker) is blocking the capability.
+
+**Solutions:**
+
+1. **Check `/dev/net/tun`**
+
+    ```bash
+    ls -l /dev/net/tun
+    lsmod | grep tun
+    ```
+
+2. **Check for rootless Docker**
+
+    ```bash
+    docker info | grep -i 'userns\|rootless'
+    ```
+
+3. Rootless Docker requires [additional capabilities](https://docs.docker.com/engine/security/rootless/#networking-errors) to pass `/dev/net/tun` through. The simplest fix is to run the analyst under normal Docker. The broader fix is documented upstream.
+
+### `ui` container: `envsubst: error while loading shared libraries`
+
+**Symptoms:**
+
+- `ui` container fails to start with a dynamic linker error about `envsubst`.
+
+**Cause:**
+
+- You've replaced the `nginx:alpine` base with a non-Alpine variant that doesn't include `gettext` by default.
+
+**Solutions:**
+
+1. Revert the base image.
+2. Or add `gettext` to the Dockerfile's runtime stage. `envsubst` is in the `gettext` package.
+
+### `ui` container: `502 Bad Gateway` on `/api/*`
+
+**Symptoms:**
+
+- The UI loads, but API calls return 502.
+
+**Causes:**
+
+- `headscale` service isn't running.
+- `ui` was started with `--no-deps`, bypassing `depends_on`.
+- The Compose project name doesn't match because the stack was started from two different directories.
+
+**Solutions:**
+
+1. **Check service state**
+
+    ```bash
+    docker compose ps
+    docker compose logs headscale
+    ```
+
+2. **Check DNS inside `ui`**
+
+    ```bash
+    docker compose exec ui sh -c 'getent hosts headscale'
+    ```
+
+3. **Restart from the repo root**
+
+    ```bash
+    docker compose down
+    docker compose up -d headscale ui
+    ```
+
+---
+
+## Task (go-task) issues
+
+### `task: command not found`
+
+**Solution:**
+
+Install go-task. See [taskfile.dev/installation](https://taskfile.dev/installation). On Ubuntu:
+
+```bash
+sudo snap install task --classic
+```
+
+### Prompts stuck in a loop
+
+**Symptoms:**
+
+- `task controlPlane` asks for the same question twice or loops.
+
+**Cause:**
+
+- The prompt writes to `.env` via `echo >> .env`. If the task fails between prompt and append, inspect `.env` for duplicates or stale entries.
+
+**Solutions:**
+
+1. **Inspect `.env`**
+
+    ```bash
+    cat .env
+    ```
+
+    Remove duplicate or empty lines.
+
+2. **Or start over**
+
+    ```bash
+    rm .env
+    task controlPlane
+    ```
+
+### `task tidy` modifies files unexpectedly
+
+**Symptoms:**
+
+- Fresh checkout followed by `task tidy` modifies `go.sum`.
+
+**Causes:**
+
+- Genuine dependency drift.
+- Your Go version differs from the one in `go.mod`'s `toolchain:` directive.
+
+**Solutions:**
+
+1. **Check your Go version**
+
+    ```bash
+    go env GOVERSION GOTOOLCHAIN
+    cat go.mod | grep -E '^(go|toolchain)'
+    ```
+
+2. If the Go versions don't match, switch to the repo's declared version. Otherwise CI and your local tidy will continually diverge.
+
+### `Taskfile.dev.yml` task not found
+
+**Symptoms:**
+
+- `task buildAnalyst` says "task not found".
+
+**Cause:**
+
+- Developer tasks live in `Taskfile.dev.yml`, not the default `Taskfile.yml`.
+
+**Solution:**
+
+Use the `-t` flag:
+
+```bash
+task -t Taskfile.dev.yml buildAnalyst
+```
+
+---
+
+## Dockerfile build failures
+
+### `go mod download` fails in analyst build stage
+
+**Symptoms:**
+
+- First-stage build fails with `cannot find module` or a hash mismatch.
+
+**Cause:**
+
+- The build context is wrong. `analyst/Dockerfile` requires `context: .` at the repo root so it can see both `go.mod` and the `analyst/src` directory. `docker build -f analyst/Dockerfile analyst/` would only see `analyst/`.
+
+**Solution:**
+
+Always build via `task build`.
+
+### Android SDK stage: `sha256sum --strict --check` fails
+
+**Symptoms:**
+
+- Build fails with `sha256sum: WARNING: 1 computed checksum did NOT match`.
+
+**Cause:**
+
+- Google changed the command-line tools archive behind the pinned filename without changing the version identifier.
+
+**Solutions:**
+
+1. **Read the current pinned archive name from the source of truth**
+
+    Check `ANDROID_TOOLS_VERSION` in `analyst/Dockerfile` or `.devcontainer/Dockerfile`, depending on which build failed.
+
+2. **Manually download and verify that archive**
+
+    ```bash
+    wget https://dl.google.com/android/repository/commandlinetools-linux-<ANDROID_TOOLS_VERSION>_latest.zip
+    sha256sum commandlinetools-linux-<ANDROID_TOOLS_VERSION>_latest.zip
+    ```
+
+3. If it actually changed, open a PR updating the checksum in every place that installs that archive. In this repo that usually means both `analyst/Dockerfile` and `.devcontainer/Dockerfile`.
+
+### `control-plane/mesh-ui` build: `pnpm install --frozen-lockfile` fails
+
+**Symptoms:**
+
+- `ERR_PNPM_OUTDATED_LOCKFILE`.
+
+**Cause:**
+
+- Someone changed `package.json` without running `pnpm install` to update `pnpm-lock.yaml`.
+
+**Solutions:**
+
+```bash
+cd control-plane/mesh-ui
+pnpm install
+git add pnpm-lock.yaml
+```
+
+---
+
+## Devcontainer issues
+
+### Devcontainer build fails on Java install
+
+**Symptoms:**
+
+- `error: unsupported architecture: 'riscv64'` or similar during the JDK stage.
+
+**Cause:**
+
+- The Dockerfile only knows about `amd64` and `arm64` (the two JDK binaries Microsoft publishes). Other host architectures fail.
+
+**Solutions:**
+
+1. Use a `linux/amd64` or `linux/arm64` host. On Apple Silicon, VS Code's devcontainer extension builds an `arm64` variant automatically.
+2. On a less common host, you need a different JDK source. Modify the Dockerfile, or don't use the devcontainer.
+
+---
+
+## Release script failures
+
+### `working tree dirty after 'task tidy' + 'task generate'`
+
+**Symptoms:**
+
+- The script aborts at the reproducibility check.
+
+**Causes:**
+
+- `go.mod` or `go.sum` has changed.
+- The tailscale submodule doesn't match upstream.
+
+**Solutions:**
+
+1. The script prints `git status --short`. If `go.mod` or `go.sum` is listed, commit the tidy changes in a separate PR first.
+2. If files under `tailscale/` are listed, the submodule HEAD is wrong:
+
+    ```bash
+    git ls-tree HEAD tailscale
+    git -C tailscale rev-parse HEAD
+    ```
+
+    The two hashes must match.
+
+### `go tool yq is not available or not v4`
+
+**Cause:**
+
+- yq is a Go tool declared in `go.mod` (see the `tool` directive). On a fresh clone it hasn't been built yet.
+
+**Solution:**
+
+```bash
+go mod download
+go tool yq --version
+```
+
+---
+
+## CI workflow failures
+
+### `pin-github-actions.yml` fails with "Some github actions versions need pinning"
+
+**Cause:**
+
+- A PR added or modified a workflow and included a non-SHA action reference.
+
+**Solution:**
+
+Run `task pinGithubActions` locally and commit the result:
+
+```bash
+task -t Taskfile.dev.yml pinGithubActions
+git add .github/workflows
+git commit -m "ci: pin github actions"
+```
+
+### `govulncheck` fails on a submodule path
+
+**Cause:**
+
+- MESH is using a tailscale package that contains (or transitively imports) a known-vulnerable Go stdlib function.
+
+**Solutions:**
+
+1. **Upgrade Go**: bump `go` in `go.mod` (and the `toolchain:` line if pinned).
+2. **Upgrade the vulnerable dependency**: if it's a direct dependency, run `go get <pkg>@latest && go mod tidy`.
+3. **Patch the tailscale submodule**: if the vulnerable code lives there, the fix goes in `github.com/BARGHEST-ngo/mesh-tailscale`.
+
+---
+
+## Getting help
+
+If you can't resolve your issue:
+
+1. **Runtime/network issues**: see [Reference Troubleshooting](../troubleshooting.md).
+2. **File an issue** with the log output from `docker compose logs` and the failing command: [github.com/BARGHEST-ngo/MESH/issues](https://github.com/BARGHEST-ngo/MESH/issues).
+3. **Supply-chain concerns** (vulnerability, key compromise, SLSA failure): see [`SECURITY.md`](https://github.com/BARGHEST-ngo/MESH/blob/main/SECURITY.md) for private disclosure.
+
+---
+
+← [CI and release](ci-and-release.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,3 +104,9 @@ nav:
       - Security: reference/security.md
       - CLI reference: reference/cli-reference.md
       - Troubleshooting: reference/troubleshooting.md
+      - Build and deploy:
+          - reference/build-deploy/index.md
+          - Runtime stack: reference/build-deploy/runtime-stack.md
+          - Build orchestration: reference/build-deploy/build-orchestration.md
+          - CI and release: reference/build-deploy/ci-and-release.md
+          - Build troubleshooting: reference/build-deploy/troubleshooting.md


### PR DESCRIPTION
## Summary

Adds a `reference/build-deploy/` docs section covering MESH's container stack, build orchestration, CI/release pipeline, and build troubleshooting.

## Test plan
- [x] `mkdocs build --strict` passes (catches broken links and nav issues)
- [ ] `deploy-docs.yml` succeeds on the PR