### PR TITLE
Docs: Update command invocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ task apikey
 ### 3. Access web UI with API key
 
 ```
-Local:  https://localhost
-Remote: https://your-domain:8443/login
+Local:  http://localhost/login
+Remote: https://<your-tunnel-or-proxy-host>/login
 ```
 
-The Web UI uses a self-signed certificate by default.
+The control plane container exposes nginx on `127.0.0.1:80` (plain HTTP). For remote access, be sure to run a reverse proxy or tunneling service (Caddy, traefik, ngrok, Cloudflare Tunnel, etc.) with TLS termination.
 
 
 > [!IMPORTANT]

--- a/docs/advanced/amneziawg.md
+++ b/docs/advanced/amneziawg.md
@@ -1,9 +1,6 @@
 # AmneziaWG configuration
 
-!!! danger
-    AmneziaWG configuration only works on the analyst client right now. Android integration is planned for February 2026.
-
-    This guide explains how to configure AmneziaWG obfuscation in MESH for censorship resistance and Deep packet inspection (DPI) evasion.
+This guide explains how to configure AmneziaWG obfuscation in MESH for censorship resistance and Deep packet inspection (DPI) evasion.
 
 ## Overview
 

--- a/docs/advanced/amneziawg.md
+++ b/docs/advanced/amneziawg.md
@@ -213,10 +213,10 @@ You can verify obfuscation by capturing packets:
 
 ```bash
 # Find WireGuard port
-sudo ss -unlp | grep tailscaled
+ss -unlp | grep mesh
 
 # Capture packets (replace PORT with actual port)
-sudo tcpdump -i any -n 'udp port PORT' -X -c 10
+tcpdump -i any -n 'udp port PORT' -X -c 10
 ```
 
 **Standard WireGuard packets** start with:

--- a/docs/advanced/amneziawg.md
+++ b/docs/advanced/amneziawg.md
@@ -269,7 +269,7 @@ If the connection works with obfuscation but not without, DPI is likely blocking
 
 - [AmneziaWG Specification](https://github.com/amnezia-vpn/amneziawg-go)
 - [WireGuard Protocol](https://www.wireguard.com/protocol/)
-- [MESH Project](https://github.com/barghest-ngo/mesh)
+- [MESH Project](https://github.com/BARGHEST-ngo/MESH)
 
 ## Next steps
 

--- a/docs/advanced/amneziawg.md
+++ b/docs/advanced/amneziawg.md
@@ -146,12 +146,11 @@ H4 = 4567890
 
 #### 1. Create Configuration File
 
-```bash
-# Create config directory
-sudo mkdir -p /etc/mesh
+The config file lives inside the analyst container at `/etc/mesh/amneziawg.conf`. Write it with `docker compose exec`:
 
+```bash
 # Create config file with balanced preset
-sudo cat > /etc/mesh/amneziawg.conf << 'EOF'
+docker compose exec analyst tee /etc/mesh/amneziawg.conf >/dev/null << 'EOF'
 [Interface]
 Jc = 5
 Jmin = 50
@@ -238,15 +237,14 @@ Test if obfuscation helps bypass restrictions:
 
 ```bash
 # Disable obfuscation
-sudo rm /etc/mesh/amneziawg.conf
-sudo systemctl restart mesh
-meshcli up --login-server=https://mesh.yourdomain.com
+docker compose exec analyst rm /etc/mesh/amneziawg.conf
+docker compose restart analyst
 
 # Test connection
-ping 100.64.X.X
+docker compose exec analyst ping 100.64.X.X
 
 # Enable obfuscation
-sudo cat > /etc/mesh/amneziawg.conf << 'EOF'
+docker compose exec analyst tee /etc/mesh/amneziawg.conf >/dev/null << 'EOF'
 [Interface]
 Jc = 5
 Jmin = 50
@@ -259,11 +257,10 @@ H3 = 300
 H4 = 400
 EOF
 
-sudo systemctl restart mesh
-meshcli up --login-server=https://mesh.yourdomain.com
+docker compose restart analyst
 
 # Test connection again
-ping 100.64.X.X
+docker compose exec analyst ping 100.64.X.X
 ```
 
 If the connection works with obfuscation but not without, DPI is likely blocking standard WireGuard.

--- a/docs/advanced/control-plane-advanced.md
+++ b/docs/advanced/control-plane-advanced.md
@@ -44,7 +44,7 @@ Deploy your own DERP relay servers for maximum privacy, geographic distribution,
 First, configure Headscale to use only your custom DERP servers:
 
 ```yaml
-# config/config.yaml
+# control-plane/headscale/config.yaml
 derp:
   server:
     enabled: false  # Disable built-in DERP server

--- a/docs/advanced/exit-node-pcap.md
+++ b/docs/advanced/exit-node-pcap.md
@@ -39,7 +39,7 @@ Before configuring exit node functionality:
 
 ### Advertise exit node to MESH network
 
-From an interactie shell in the analyst container, advertise the analyst node as an exit node:
+From an interactive shell in the analyst container, advertise the analyst node as an exit node:
 
 ```bash
 # Advertise on connect (first time)
@@ -49,7 +49,7 @@ meshcli up --advertise-exit-node
 meshcli set --advertise-exit-node
 ```
 
-Once the Tailescale daemon advertises the exit-node routes, the analyst node will show up in the control plane Web UI with an APPROVE EXIT button.
+Once the Tailscale daemon advertises the exit-node routes, the analyst node will show up in the control plane Web UI with an APPROVE EXIT button.
 
 ### Enable exit node on control plane
 

--- a/docs/advanced/exit-node-pcap.md
+++ b/docs/advanced/exit-node-pcap.md
@@ -96,17 +96,14 @@ meshcli status
 
 ### Enable exit node on control plane
 
-On the control plane, approve the exit node:
+In the control plane Web UI, approve the analyst node as an exit node:
 
-```bash
-# List nodes
-docker compose exec headscale headscale nodes list
+1. Open the control plane Web UI and authenticate using a Headscale API key (`task apikey`).
+2. On the home page, expand the network section containing the analyst node.
+3. Find the analyst node in the node list and click the **APPROVE EXIT** button on its row.
+4. Confirm the prompt.
 
-# Find your analyst workstation node ID
-# Enable exit node for that node
-docker compose exec headscale headscale routes enable --node <NODE_ID> --route 0.0.0.0/0
-docker compose exec headscale headscale routes enable --node <NODE_ID> --route ::/0
-```
+Once approved, the analyst node will appear with an exit-node indicator and other peers can route through it.
 
 ### Configure endpoint to use exit node
 
@@ -505,8 +502,8 @@ find /var/captures -name "*.pcap" -mtime +90 -delete
 4. **Check control plane approved routes:**
 
    ```bash
-   docker compose exec headscale headscale routes list
-   # Should show 0.0.0.0/0 and ::/0 enabled
+   docker compose exec headscale headscale nodes list-routes
+   # Should show 0.0.0.0/0 and ::/0 approved on the analyst node
    ```
 
 ### Packet capture not capturing traffic

--- a/docs/advanced/exit-node-pcap.md
+++ b/docs/advanced/exit-node-pcap.md
@@ -31,68 +31,25 @@ An exit node routes all internet traffic from endpoint devices through the analy
 Before configuring exit node functionality:
 
 1. **Working MESH deployment** - Complete the [Getting started guide](../setup/index.md)
-2. **Analyst node** - A locked down, virutal linux node with sufficient storage for packet captures
-3. **Root access** - Required for configuring routing and packet capture
-4. **Technical skills** - Familiar with networking, iptables, and packet analysis
+2. **Analyst node** - A locked down, virtual linux node with sufficient storage for packet captures
+3. **Root access** - Required to run docker and capture packets
+4. **Technical skills** - Familiar with networking and packet analysis
 
 ## Configure analyst node as exit node
 
-### Enable IP forwarding
-
-Enable IP forwarding on the analyst node:
-
-```bash
-# Enable IP forwarding temporarily
-sudo sysctl -w net.ipv4.ip_forward=1
-sudo sysctl -w net.ipv6.conf.all.forwarding=1
-
-# Make permanent (survives reboot)
-echo "net.ipv4.ip_forward=1" | sudo tee -a /etc/sysctl.conf
-echo "net.ipv6.conf.all.forwarding=1" | sudo tee -a /etc/sysctl.conf
-sudo sysctl -p
-```
-
-### Configure NAT for exit node traffic (optional)
-
-Set up NAT (Network Address Translation) to route endpoint traffic:
-
-```bash
-# Get your primary network interface
-PRIMARY_INTERFACE=$(ip route | grep default | awk '{print $5}')
-echo "Primary interface: $PRIMARY_INTERFACE"
-
-# Get MESH interface (usually mesh0 or tailscale0)
-MESH_INTERFACE=$(ip link | grep -E 'mesh0|tailscale0' | awk -F: '{print $2}' | tr -d ' ')
-echo "MESH interface: $MESH_INTERFACE"
-
-# Configure NAT for MESH traffic
-sudo iptables -t nat -A POSTROUTING -o $PRIMARY_INTERFACE -j MASQUERADE
-sudo iptables -A FORWARD -i $MESH_INTERFACE -o $PRIMARY_INTERFACE -j ACCEPT
-sudo iptables -A FORWARD -i $PRIMARY_INTERFACE -o $MESH_INTERFACE -m state --state RELATED,ESTABLISHED -j ACCEPT
-
-# Save iptables rules (Ubuntu/Debian)
-sudo apt install -y iptables-persistent
-sudo netfilter-persistent save
-
-# Save iptables rules (RHEL/CentOS)
-# sudo service iptables save
-```
-
 ### Advertise exit node to MESH network
 
-Configure the analyst workstation to advertise as an exit node using this sub command:
+From an interactie shell in the analyst container, advertise the analyst node as an exit node:
 
 ```bash
-# Advertise as exit node
+# Advertise on connect (first time)
 meshcli up --advertise-exit-node
 
-# Advertise as exit node when already connected
+# Or if already connected, toggle the setting
 meshcli set --advertise-exit-node
-
-# Verify exit node is advertised
-meshcli status
-# Should show: "Exit node: advertising"
 ```
+
+Once the Tailescale daemon advertises the exit-node routes, the analyst node will show up in the control plane Web UI with an APPROVE EXIT button.
 
 ### Enable exit node on control plane
 
@@ -119,16 +76,6 @@ On the endpoint device (Android), configure it to use the exit node:
 !!! warning "You should instruct the user to disable Magic DNS in the settings"
     Using MESH's Magic DNS (which supports connectivity between nodes) will make DNS queries on the device fail since the device needs to use it's own DNS configuration. Thus disabling Magic DNS in the setting tap will make regular DNS queries allowable.
 
-**Via meshcli (if available on endpoint):**
-
-```bash
-# Use specific exit node
-meshcli up --exit-node=<ANALYST_MESH_IP>
-
-# Use any available exit node
-meshcli up --exit-node-allow-lan-access
-```
-
 ## Packet capture (PCAP)
 
 Capture network traffic from endpoint devices for forensic analysis.
@@ -139,18 +86,10 @@ Capture network traffic from endpoint devices for forensic analysis.
 **Wireshark** - GUI packet analyser (recommended for analysis)
 **tshark** - Command-line Wireshark (good for scripting)
 
-### Install packet capture tools
+### Install packet capture tools in analyst container
 
 ```bash
-# Ubuntu/Debian
-sudo apt install -y tcpdump wireshark tshark
-
-# RHEL/CentOS
-sudo yum install -y tcpdump wireshark
-
-# Allow non-root users to capture packets (optional)
-sudo usermod -aG wireshark $USER
-# Log out and back in for group membership to take effect
+apt install -y tcpdump wireshark tshark
 ```
 
 ### Capture all traffic from specific endpoint
@@ -162,11 +101,11 @@ Capture all traffic from a specific endpoint device:
 ENDPOINT_IP="100.64.2.1"  # Replace with actual endpoint mesh IP
 
 # Capture all traffic to/from endpoint
-sudo tcpdump -i any -w endpoint-capture.pcap \
+tcpdump -i any -w endpoint-capture.pcap \
   "host $ENDPOINT_IP"
 
 # Capture with rotation (new file every 100MB, keep 10 files)
-sudo tcpdump -i any -w endpoint-capture.pcap -C 100 -W 10 \
+tcpdump -i any -w endpoint-capture.pcap -C 100 -W 10 \
   "host $ENDPOINT_IP"
 ```
 
@@ -175,11 +114,8 @@ sudo tcpdump -i any -w endpoint-capture.pcap -C 100 -W 10 \
 Capture only traffic that's being routed through the exit node (not MESH internal traffic):
 
 ```bash
-# Get primary network interface
-PRIMARY_INTERFACE=$(ip route | grep default | awk '{print $5}')
-
 # Capture only exit node traffic (traffic leaving to internet)
-sudo tcpdump -i $PRIMARY_INTERFACE -w exit-node-traffic.pcap \
+tcpdump -i eth0 -w exit-node-traffic.pcap \
   "src $ENDPOINT_IP or dst $ENDPOINT_IP"
 ```
 
@@ -189,19 +125,19 @@ Capture only specific types of traffic:
 
 ```bash
 # Capture only HTTP/HTTPS traffic
-sudo tcpdump -i any -w http-traffic.pcap \
+tcpdump -i any -w http-traffic.pcap \
   "host $ENDPOINT_IP and (port 80 or port 443)"
 
 # Capture only DNS queries
-sudo tcpdump -i any -w dns-traffic.pcap \
+tcpdump -i any -w dns-traffic.pcap \
   "host $ENDPOINT_IP and port 53"
 
 # Capture only TLS/SSL traffic
-sudo tcpdump -i any -w tls-traffic.pcap \
+tcpdump -i any -w tls-traffic.pcap \
   "host $ENDPOINT_IP and tcp port 443"
 
 # Capture only non-encrypted HTTP
-sudo tcpdump -i any -w http-plain.pcap \
+tcpdump -i any -w http-plain.pcap \
   "host $ENDPOINT_IP and tcp port 80"
 ```
 
@@ -215,7 +151,7 @@ CAPTURE_DIR="captures/$(date +%Y%m%d_%H%M%S)_endpoint_$ENDPOINT_IP"
 mkdir -p "$CAPTURE_DIR"
 
 # Capture with detailed logging
-sudo tcpdump -i any -w "$CAPTURE_DIR/capture.pcap" \
+tcpdump -i any -w "$CAPTURE_DIR/capture.pcap" \
   -v -tttt \
   "host $ENDPOINT_IP" \
   2>&1 | tee "$CAPTURE_DIR/capture.log"
@@ -238,23 +174,23 @@ Common capture filters for forensic scenarios:
 
 ```bash
 # Capture all traffic except MESH internal (only exit node traffic)
-sudo tcpdump -i any -w forensic.pcap \
+tcpdump -i any -w forensic.pcap \
   "host $ENDPOINT_IP and not (dst net 100.64.0.0/10)"
 
 # Capture potential C2 traffic (non-standard ports)
-sudo tcpdump -i any -w c2-traffic.pcap \
+tcpdump -i any -w c2-traffic.pcap \
   "host $ENDPOINT_IP and not (port 80 or port 443 or port 53)"
 
 # Capture potential data exfiltration (large uploads)
-sudo tcpdump -i any -w uploads.pcap \
+tcpdump -i any -w uploads.pcap \
   "host $ENDPOINT_IP and tcp[tcpflags] & tcp-push != 0"
 
 # Capture DNS queries (identify contacted domains)
-sudo tcpdump -i any -w dns.pcap -v \
+tcpdump -i any -w dns.pcap -v \
   "host $ENDPOINT_IP and port 53"
 
 # Capture TLS SNI (Server Name Indication) for HTTPS domains
-sudo tcpdump -i any -w tls-sni.pcap -v \
+tcpdump -i any -w tls-sni.pcap -v \
   "host $ENDPOINT_IP and tcp port 443"
 ```
 
@@ -478,25 +414,25 @@ find /var/captures -name "*.pcap" -mtime +90 -delete
 
 **Solutions:**
 
-1. **Verify IP forwarding is enabled:**
+1. **Verify IP forwarding is enabled inside the analyst container:**
 
    ```bash
-   sysctl net.ipv4.ip_forward
-   # Should show: net.ipv4.ip_forward = 1
+   docker compose exec analyst cat /proc/sys/net/ipv4/ip_forward
+   # Should show: 1
    ```
 
 2. **Check iptables rules:**
 
    ```bash
-   sudo iptables -t nat -L -n -v
-   # Should show MASQUERADE rule
+   docker compose exec analyst iptables -t nat -L ts-postrouting -n
+   # Should show a MASQUERADE rule
    ```
 
 3. **Verify exit node is advertised:**
 
    ```bash
-   meshcli status
-   # Should show: "Exit node: advertising"
+   docker compose exec analyst mesh cli status --json | grep -E 'AllowedIPs|ExitNodeOption'
+   # AllowedIPs should include 0.0.0.0/0 and ::/0
    ```
 
 4. **Check control plane approved routes:**
@@ -522,14 +458,14 @@ find /var/captures -name "*.pcap" -mtime +90 -delete
    ip link show
 
    # Capture on all interfaces
-   sudo tcpdump -i any -w test.pcap
+   tcpdump -i any -w test.pcap
    ```
 
 2. **Check capture filter:**
 
    ```bash
    # Test filter syntax
-   sudo tcpdump -i any "host $ENDPOINT_IP" -c 10
+   tcpdump -i any "host $ENDPOINT_IP" -c 10
    ```
 
 3. **Verify endpoint is using exit node:**
@@ -544,7 +480,7 @@ find /var/captures -name "*.pcap" -mtime +90 -delete
 
    ```bash
    # Ensure running as root or with CAP_NET_RAW capability
-   sudo tcpdump -i any -w test.pcap
+   tcpdump -i any -w test.pcap
    ```
 
 ### High disk usage from captures
@@ -560,14 +496,14 @@ find /var/captures -name "*.pcap" -mtime +90 -delete
 
    ```bash
    # Limit to 10 files of 100MB each (1GB total)
-   sudo tcpdump -i any -w capture.pcap -C 100 -W 10 "host $ENDPOINT_IP"
+   tcpdump -i any -w capture.pcap -C 100 -W 10 "host $ENDPOINT_IP"
    ```
 
 2. **Use more specific filters:**
 
    ```bash
    # Only capture specific protocols
-   sudo tcpdump -i any -w capture.pcap "host $ENDPOINT_IP and (port 80 or port 443)"
+   tcpdump -i any -w capture.pcap "host $ENDPOINT_IP and (port 80 or port 443)"
    ```
 
 3. **Compress old captures:**
@@ -629,11 +565,11 @@ find /var/captures -name "*.pcap" -mtime +90 -delete
 
 ```bash
 # Increase kernel buffer size
-sudo sysctl -w net.core.rmem_max=134217728
-sudo sysctl -w net.core.rmem_default=134217728
+echo 134217728 > /proc/sys/net/core/rmem_max
+echo 134217728 > /proc/sys/net/core/rmem_default
 
 # Use larger tcpdump buffer
-sudo tcpdump -i any -w capture.pcap -B 65536 "host $ENDPOINT_IP"
+tcpdump -i any -w capture.pcap -B 65536 "host $ENDPOINT_IP"
 ```
 
 **For long-term captures:**
@@ -645,22 +581,14 @@ sudo tcpdump -i any -w capture.pcap -B 65536 "host $ENDPOINT_IP"
 
 ### Security hardening
 
-**Restrict access to capture tools:**
-
-```bash
-# Only allow specific users to capture
-sudo chmod 750 /usr/sbin/tcpdump
-sudo chgrp forensics /usr/sbin/tcpdump
-```
-
 **Audit capture activity:**
 
 ```bash
 # Log all tcpdump usage
-sudo auditctl -w /usr/sbin/tcpdump -p x -k packet_capture
+auditctl -w /usr/sbin/tcpdump -p x -k packet_capture
 
 # View audit logs
-sudo ausearch -k packet_capture
+ausearch -k packet_capture
 ```
 
 ## Next steps

--- a/docs/overview/features.md
+++ b/docs/overview/features.md
@@ -99,11 +99,11 @@ MESH works seamlessly with industry-standard forensic tools:
 
 !!! example "Example: Remote AndroidQF collection"
     ```bash
-    # Connect to device over mesh
-    adb connect 100.64.2.1:5555
+    # Connect and pair to device over mesh
+    meshcli adbpair --host 100.64.2.1 --hostport 1234 --pairport 4321 --code 123456
 
     # Run AndroidQF spyware scan
-    androidqf --adb 100.64.2.1:5555 --output ./artifacts/
+    meshcli adbcollect
     ```
 
 ## Forensic workflows

--- a/docs/overview/use-cases.md
+++ b/docs/overview/use-cases.md
@@ -52,16 +52,16 @@ An incident response team needs to monitor network traffic from a compromised de
 
 !!! example "Workflow"
     ```bash
-    # Enable exit node on analyst node
+    # Enable exit node in analyst container
     meshcli up --advertise-exit-node
+
+    # In the control plane Web UI, click APPROVE EXIT on the analyst's node.
 
     # On endpoint, route all traffic through analyst
     # (configured in MESH app)
-    
-    # Enable port forwarding on analyst 
 
-    # Capture traffic on analyst workstation
-    tcpdump -i mesh0 -w capture.pcap
+    # Capture traffic in the analyst container:
+    tcpdump -i tailscale0 -w capture.pcap
     ```
 
 ## Human rights investigations

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -29,7 +29,7 @@ meshcli up [options]
 **Options:**
 
 - `--login-server <url>`: Control plane URL (required)
-- `--authkey <key>`: Pre-authentication key
+- `--auth-key <key>`: Pre-authentication key
 - `--accept-dns <bool>`: Accept DNS configuration (default: true)
 - `--accept-routes <bool>`: Accept subnet routes from peers (default: false)
 - `--advertise-routes <routes>`: Advertise subnet routes (comma-separated CIDRs)
@@ -53,7 +53,7 @@ meshcli up --login-server=https://mesh.example.com
 # Connect with pre-auth key
 meshcli up \
   --login-server=https://mesh.example.com \
-  --authkey=abc123def456
+  --auth-key=abc123def456
 
 # Advertise subnet routes
 meshcli up \
@@ -417,7 +417,7 @@ meshcli status --json | jq -r '.Peer[] | select(.Online == true) | .HostName'
 while true; do
     if ! meshcli status | grep -q "Running"; then
         echo "Disconnected, reconnecting..."
-        meshcli up --login-server=https://mesh.example.com --authkey=abc123
+        meshcli up --login-server=https://mesh.example.com --auth-key=abc123
     fi
     sleep 60
 done

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -10,7 +10,7 @@ meshcli [global-options] <command> [command-options]
 
 ## Global Options
 
-- `--socket <path>`: Path to tailscaled socket (default: `/var/run/mesh/tailscaled.sock`)
+- `--socket <path>`: Path to tailscaled socket (default: `/tmp/tailscaled.sock`)
 - `--help`, `-h`: Show help message
 - `--version`, `-v`: Show version information
 
@@ -362,7 +362,7 @@ sudo -E meshcli up --login-server=https://mesh.example.com
 
 ### State File
 
-Location: `/var/lib/mesh/tailscaled.state`
+Location: `/root/.tailscale/tailscaled.state` inside the analyst container, persisted via the `analyst-data` volume.
 
 Contains:
 
@@ -373,7 +373,7 @@ Contains:
 **Backup:**
 
 ```bash
-sudo cp /var/lib/mesh/tailscaled.state /var/lib/mesh/tailscaled.state.backup
+docker compose exec analyst cp /root/.tailscale/tailscaled.state /root/.tailscale/tailscaled.state.backup
 ```
 
 ### AmneziaWG Config

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -301,22 +301,6 @@ meshcli ip -4
 meshcli ip -1
 ```
 
-### routes
-
-Show and manage routes.
-
-**Synopsis:**
-
-```bash
-meshcli routes
-```
-
-**Examples:**
-
-```bash
-meshcli routes
-```
-
 ### version
 
 Show version information.

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -104,7 +104,6 @@ meshcli status [options]
 
 **Options:**
 
-- `--peers`: Show detailed peer information
 - `--json`: Output in JSON format
 - `--self <bool>`: Show self information (default: true)
 - `--active`: Only show active peers
@@ -328,11 +327,11 @@ meshcli version
 ```bash
 # Prevent peer trimming
 export TS_DEBUG_TRIM_WIREGUARD=false
-sudo -E meshcli up --login-server=https://mesh.example.com
+meshcli up --login-server=https://mesh.example.com
 
 # Force DERP relay
 export TS_DEBUG_ALWAYS_USE_DERP=true
-sudo -E meshcli up --login-server=https://mesh.example.com
+meshcli up --login-server=https://mesh.example.com
 ```
 
 ## Exit Codes

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -19,7 +19,7 @@ prefixes:
 
 derp:
   server:
-    enabled: false
+    enabled: true
     region_id: 999
     region_code: "headscale"
     region_name: "Headscale Embedded DERP"
@@ -30,8 +30,7 @@ derp:
     ipv4: 198.51.100.1
     ipv6: 2001:db8::1
 
-  urls:
-   - https://controlplane.tailscale.com/derpmap/default
+  urls: []
 
   paths: []
   auto_update_enabled: false
@@ -175,7 +174,9 @@ dns:
   nameservers:
     global:
       - 1.1.1.1
-      - 8.8.8.8
+      - 1.0.0.1
+      - 2606:4700:4700::1111
+      - 2606:4700:4700::1001
 ```
 
 DNS settings for mesh nodes.
@@ -227,14 +228,14 @@ DERP is an encrypted relay protocol that acts as a fallback when direct peer-to-
 ```yaml
 derp:
   server:
-    enabled: false
+    enabled: true
     region_id: 999
-    region_code: "MESH"
-    region_name: "PEOPLES_REPUBLIC_OF_BARGHEST"
+    region_code: "headscale"
+    region_name: "Headscale Embedded DERP"
     stun_listen_addr: "0.0.0.0:3478"
 ```
 
-MESH includes a built-in DERP server for convenience. By default, the control plane acting as the DERP relay is set to false. This is because it automatically uses the [Tailscale DERP relays](https://login.tailscale.com/derpmap/default).
+MESH includes a built-in DERP server and runs it by default (`enabled: true`). The example Headscale config sets `derp.urls: []`, so the control plane only uses its own embedded DERP relay. It does not include the [Tailscale DERP relays](https://login.tailscale.com/derpmap/default).
 
 !!! danger "Is DERP safe?"
     MESH'sarchitecture is end-to-end encrypted using WireGuard between your devices. That holds whether traffic is direct or relayed through DERP. Because of that DERP can see:

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -57,24 +57,21 @@ meshcli down
 # List nodes
 docker compose exec headscale headscale nodes list
 
-# Create pre-auth key
-docker compose exec headscale headscale preauthkeys create --user default --expiration 24h
-
-# List users
+# List networks
 docker compose exec headscale headscale users list
 
 # Check ACL policy
-docker compose exec headscale headscale policy check
+docker compose exec headscale headscale policy get
 ```
 
 #### Android Forensics
 
 ```bash
 # Connect to device
-adb connect 100.64.x.x:5555
+meshcli adbpair --host 100.64.x.x --hostport 1234 --pairport 1234 --code 1234
 
 # Run AndroidQF
-androidqf --adb 100.64.x.x:5555 --output ./artifacts/
+meshcli adbcollect
 
 # Run MVT
 mvt-android check-adb --output ./mvt-output/

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -68,7 +68,7 @@ docker compose exec headscale headscale policy get
 
 ```bash
 # Connect to device
-meshcli adbpair --host 100.64.x.x --hostport 1234 --pairport 1234 --code 1234
+meshcli adbpair --host 100.64.x.x --hostport 1234 --pairport 4321 --code 123456
 
 # Run AndroidQF
 meshcli adbcollect
@@ -84,7 +84,7 @@ mvt-android check-adb --output ./mvt-output/
 | Can't connect to control plane | Check firewall, verify URL, check logs |
 | Nodes can't see each other | Check ACL policy, verify routes |
 | ADB connection fails | Enable ADB over network on device |
-| Web UI not accessible | Check port 8443, verify TLS certificate |
+| Web UI not accessible | Check port 80 on the host, verify reverse-proxy/tunnel for remote access |
 | High latency | Check if using DERP relay, prefer P2P |
 
 [:octicons-arrow-right-24: Full Troubleshooting guide](troubleshooting.md)
@@ -93,11 +93,8 @@ mvt-android check-adb --output ./mvt-output/
 
 | Port | Service | Protocol | Purpose |
 |------|---------|----------|---------|
-| 8080 | Headscale | HTTP | Control plane API |
-| 8443 | Headscale-UI | HTTPS | Web management interface |
+| 80 | MESH web UI | HTTP | Web management interface |
 | 3478 | DERP | UDP/TCP | STUN for NAT traversal |
-| 41641 | WireGuard | UDP | Encrypted mesh traffic |
-| 5555 | ADB | TCP | Android Debug Bridge |
 
 ### Network Ranges
 

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -19,11 +19,10 @@ Pre-auth keys should be rotated regularly:
 # List existing keys
 docker compose exec headscale headscale preauthkeys list
 
-# Expire old keys
-docker compose exec headscale headscale preauthkeys expire --user default KEY_ID
+# Expire old keys (KEY_ID is the numeric ID from `preauthkeys list`)
+docker compose exec headscale headscale preauthkeys expire -i KEY_ID
 
-# Create new key
-docker compose exec headscale headscale preauthkeys create --user default --reusable --expiration 24h
+Then follow the instructions in [Create a Pre-authentication key](../setup/control-plane.md#step-6-create-a-pre-authentication-key) for creating a new key.
 ```
 
 **Best practices:**

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -41,8 +41,8 @@ Common issues and solutions for MESH deployments.
 4. **Verify control plane is running**
 
    ```bash
-   docker ps | grep headscale
-   docker logs headscale
+   docker compose ps | grep headscale
+   docker compose logs headscale
    ```
 
 5. **Check reverse proxy**
@@ -79,21 +79,11 @@ Common issues and solutions for MESH deployments.
 
 2. **Generate new key**
 
-   ```bash
-   docker compose exec headscale headscale preauthkeys create --expiration 24h --reusable
-   ```
+   Pre-auth keys allow nodes to join the mesh without interactive authentication. See the [Create a Pre-authentication key](../setup/control-plane.md#step-6-create-a-pre-authentication-key) instructions for details.
 
 3. **Check key expiration**
    - Pre-auth keys expire after the specified time
    - Generate a new key if expired
-
-4. **Try interactive authentication**
-
-   ```bash
-   # Without --authkey
-   meshcli up --login-server=https://mesh.yourdomain.com
-   # Follow the URL to authenticate
-   ```
 
 ### No Mesh IP Assigned
 
@@ -115,25 +105,23 @@ Common issues and solutions for MESH deployments.
 2. **Check control plane logs**
 
    ```bash
-   docker logs headscale
+   docker compose logs headscale
    # Look for registration errors
    ```
 
-3. **Ensure user exists**
+3. **Ensure MESH network exists**
 
    ```bash
-   # List users
+   # List networks
    docker compose exec headscale headscale users list
-
-   # Create user if missing
-   docker compose exec headscale headscale users create default
    ```
+
+If the network does not exist, it can be created by following the [Create a new network](../setup/control-plane.md#step-5-create-a-new-network) instructions.
 
 4. **Try reconnecting**
 
    ```bash
-   meshcli down
-   meshcli up --login-server=https://mesh.yourdomain.com --authkey=YOUR_KEY
+   docker compose restart analyst
    ```
 
 5. **Check node registration**
@@ -199,7 +187,7 @@ Common issues and solutions for MESH deployments.
 
 **Symptoms:**
 
-- `meshcli status --peers` shows no peers
+- `meshcli status` shows no peers
 - Devices don't appear in mesh
 - Can't ping peers
 
@@ -217,8 +205,12 @@ Common issues and solutions for MESH deployments.
    ```bash
    # On control plane
    docker compose exec headscale headscale nodes list
-   cat config/acl.yaml
+
+   # Print the active policy
+   docker compose exec headscale headscale policy get
    ```
+
+   The policy can also be inspected and edited from the CUSTOMIZE ACL page in the control plane web UI.
 
 3. **Verify same control plane**
    - Ensure all devices connect to the same control plane URL
@@ -274,7 +266,7 @@ Common issues and solutions for MESH deployments.
 5. **Monitor logs**
 
    ```bash
-   sudo journalctl -u mesh -f
+   docker compose logs -f analyst
    # Look for errors or warnings
    ```
 
@@ -284,7 +276,7 @@ Common issues and solutions for MESH deployments.
 
 **Symptoms:**
 
-- `adb connect` fails
+- `meshcli adbpair` fails
 - "Connection refused" error
 - "Unable to connect" error
 
@@ -293,7 +285,7 @@ Common issues and solutions for MESH deployments.
 1. **Verify device is online**
 
    ```bash
-   meshcli status --peers
+   meshcli status
    ping 100.64.X.X
    ```
 
@@ -372,7 +364,7 @@ Common issues and solutions for MESH deployments.
 1. **Check connection type**
 
    ```bash
-   meshcli status --json | jq '.Peer[] | {name: .HostName, addr: .CurAddr}'
+   meshcli status
    # Direct connection is faster than DERP relay
    ```
 
@@ -380,8 +372,8 @@ Common issues and solutions for MESH deployments.
 
    ```bash
    # If not needed for censorship resistance
-   sudo rm /etc/mesh/amneziawg.conf
-   sudo systemctl restart mesh
+   docker compose exec analyst rm -f /etc/mesh/amneziawg.conf
+   docker compose restart analyst
    ```
 
 3. **Use lighter obfuscation**
@@ -418,23 +410,9 @@ Common issues and solutions for MESH deployments.
    - AmneziaWG adds CPU overhead
    - Disable if not needed
 
-2. **Reduce connection checks**
-
-   ```bash
-   # Increase check interval
-   meshcli set --netcheck-interval=10m
-   ```
-
-3. **Limit peer count**
+2. **Limit peer count**
    - Use ACLs to limit visible peers
    - Only connect to necessary devices
-
-4. **Check for loops**
-
-   ```bash
-   # Look for routing loops
-   meshcli routes
-   ```
 
 ## Control plane Issues
 
@@ -451,7 +429,7 @@ Common issues and solutions for MESH deployments.
 1. **Check logs**
 
    ```bash
-   docker logs headscale
+   docker compose logs headscale
    ```
 
 2. **Check port conflicts**
@@ -465,23 +443,16 @@ Common issues and solutions for MESH deployments.
 3. **Verify config syntax**
 
    ```bash
-   cat config/config.yaml
+   cat control-plane/headscale/config.yaml
    # Check for YAML syntax errors
    ```
 
-4. **Check database**
+4. **Reset database (WARNING: deletes all data)**
 
    ```bash
-   ls -la data/db.sqlite
-   sudo chown -R 1000:1000 data/
-   ```
-
-5. **Reset database (WARNING: deletes all data)**
-
-   ```bash
-   docker-compose down
-   rm data/db.sqlite
-   docker-compose up -d
+   task down
+   docker volume rm mesh_headscale-data
+   task controlPlane
    ```
 
 ### Nodes Not Registering
@@ -500,30 +471,21 @@ Common issues and solutions for MESH deployments.
    docker compose exec headscale headscale nodes list
    ```
 
-2. **Check user exists**
+2. **Check network exists**
 
    ```bash
    docker compose exec headscale headscale users list
    ```
 
-3. **Create user if missing**
+3. **Create network if missing**
 
-   ```bash
-   docker compose exec headscale headscale users create analyst1
-   ```
+   If the network does not exist, it can be created by following the [Create a new network](../setup/control-plane.md#step-5-create-a-new-network) instructions.
 
 4. **Check ACLs**
 
    ```bash
-   cat config/acl.yaml
+   docker compose exec headscale headscale policy get
    # Verify ACLs allow the connection
-   ```
-
-5. **Register manually**
-
-   ```bash
-   # Get node key from client logs
-   docker compose exec headscale headscale nodes register --user analyst1 --key nodekey:abc123
    ```
 
 ### DERP Relay Not Working
@@ -540,7 +502,7 @@ Common issues and solutions for MESH deployments.
 
    ```bash
    sudo netstat -ulnp | grep 3478
-   docker logs headscale | grep STUN
+   docker compose logs headscale | grep STUN
    ```
 
 2. **Test STUN**
@@ -553,7 +515,7 @@ Common issues and solutions for MESH deployments.
 3. **Check DERP config**
 
    ```bash
-   cat config/config.yaml | grep -A 20 "derp:"
+   cat control-plane/headscale/config.yaml | grep -A 20 "derp:"
    ```
 
 4. **Verify DERP is enabled**
@@ -632,10 +594,10 @@ Common issues and solutions for MESH deployments.
 
 ```bash
 # Analyst client logs
-sudo journalctl -u mesh --since "1 hour ago" > mesh-logs.txt
+docker compose logs --since 1h analyst > mesh-logs.txt
 
 # Control plane logs
-docker logs headscale > headscale-logs.txt
+docker compose logs --since 1h headscale > headscale-logs.txt
 
 # Android logs
 adb logcat -d > android-logs.txt
@@ -669,7 +631,7 @@ sudo wg show
 
 ```bash
 # Detailed status
-meshcli status --json | jq
+meshcli status --json
 
 # Check peer connectivity
 for peer in $(meshcli status --json | jq -r '.Peer[].TailscaleIPs[0]'); do

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -18,7 +18,7 @@ Common issues and solutions for MESH deployments.
 
    ```bash
    curl https://mesh.yourdomain.com/health
-   # Should return: {"status":"ok"}
+   # Should return: {"status":"pass"}
    ```
 
 2. **Check DNS resolution**
@@ -116,7 +116,7 @@ Common issues and solutions for MESH deployments.
    docker compose exec headscale headscale users list
    ```
 
-If the network does not exist, it can be created by following the [Create a new network](../setup/control-plane.md#step-5-create-a-new-network) instructions.
+   If the network does not exist, it can be created by following the [Create a new network](../setup/control-plane.md#step-5-create-a-new-network) instructions.
 
 4. **Try reconnecting**
 
@@ -553,7 +553,8 @@ If the network does not exist, it can be created by following the [Create a new 
 
    ```bash
    adb uninstall com.barghest.mesh
-   adb install mesh-android.apk
+   # Replace with the version you have, e.g. mesh-0.1.6-alpha.apk
+   adb install mesh-<version>.apk
    ```
 
 3. **Check logs**
@@ -640,7 +641,7 @@ for peer in $(meshcli status --json | jq -r '.Peer[].TailscaleIPs[0]'); do
 done
 
 # Monitor connection changes
-watch -n 1 'meshcli status --peers'
+watch -n 1 'meshcli status'
 ```
 
 ## Getting Help

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -180,7 +180,7 @@ Common issues and solutions for MESH deployments.
 
    ```bash
    export TS_DEBUG_ALWAYS_USE_DERP=false
-   sudo -E meshcli up --login-server=https://mesh.yourdomain.com
+   meshcli up --login-server=https://mesh.yourdomain.com
    ```
 
 ### Peers Not Visible
@@ -622,10 +622,6 @@ meshcli netcheck
 
 # Trace route to peer
 meshcli ping 100.64.X.X --verbose
-
-# Check WireGuard interface
-ip addr show tun0
-sudo wg show
 ```
 
 ### Connection Diagnostics

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -294,7 +294,7 @@ If the network does not exist, it can be created by following the [Create a new 
    ```bash
    # On Android device (via USB)
    adb shell getprop service.adb.tcp.port
-   # Should return 5555
+   # Should return a valid port number
    ```
 
 3. **Enable ADB-over-WiFi**

--- a/docs/setup/control-plane.md
+++ b/docs/setup/control-plane.md
@@ -72,7 +72,7 @@ You're now connected to the control plane.
 
 Before creating pre-authentication keys for nodes, you need to create a network (or namespace). This should be the network that you'll join nodes to for a forensics mesh.
 
-- Navigate to the **[ NEW NETWORK ]** tab in the sidebar
+- Click the **[ NEW NETWORK ]** button on the home page
 
 ![alt text](image-1.png)
 
@@ -92,7 +92,7 @@ For production deployments, see the [ACL documentation](../reference/policies.md
 
 Pre-auth keys allow nodes to join the mesh without interactive authentication. You'll need this key to connect clients.
 
-1. Click the **[ GENERATE KEY TO ADD CLIENTS ]** tab
+1. Click the **[ GENERATE KEY TO ADD CLIENTS ]** button on a network
 2. Select which type of node you want to create
 
     ![alt text](image-4.png)
@@ -120,6 +120,7 @@ docker compose logs
 
 # Test control plane API endpoint
 curl https://your-domain.com/health
+# Returns: {"status":"pass"}
 ```
 
 ## Next steps

--- a/docs/setup/control-plane.md
+++ b/docs/setup/control-plane.md
@@ -34,6 +34,7 @@ When first run, you will be prompted for the type of control plane you want to d
 Verify the containers are running:
 
 ```bash
+docker compose ps
 docker compose logs
 ```
 

--- a/docs/setup/endpoint-client.md
+++ b/docs/setup/endpoint-client.md
@@ -62,8 +62,8 @@ You should see your device listed. If prompted on the device, tap **"Allow"** to
 # Install the APK using ADB
 adb install mesh-release-unsigned.apk
 
-# Or if you downloaded from GitHub
-adb install mesh-0.1.1-alpha.apk
+# Or if you downloaded from GitHub (replace with the version you downloaded)
+adb install mesh-0.1.6-alpha.apk
 ```
 
 **4. Verify installation:**

--- a/docs/setup/endpoint-client.md
+++ b/docs/setup/endpoint-client.md
@@ -15,7 +15,7 @@ Download the APK from [GitHub Releases](https://github.com/BARGHEST-ngo/mesh/rel
 
 ```bash
 # Build the release APK
-task buildAndroidRelease
+task -t Taskfile.dev.yml buildAndroidRelease
 ```
 
 The APK will be created at:
@@ -264,7 +264,7 @@ You should see your Android device listed with its mesh IP address.
 The APK may be corrupted. Try rebuilding:
 
 ```bash
-task clean && task buildAndroidRelease
+task -t Taskfile.dev.yml clean && task -t Taskfile.dev.yml buildAndroidRelease
 ```
 
 ### Can't connect to control plane

--- a/docs/setup/verification.md
+++ b/docs/setup/verification.md
@@ -169,7 +169,7 @@ If you have AndroidQF installed, you can run automated spyware detection:
 
 ```bash
 # Run AndroidQF against the mesh-connected device
-androidqf --adb 100.64.2.1:5555 --output ./artifacts/
+meshcli adbcollect
 ```
 
 AndroidQF will:
@@ -178,9 +178,6 @@ AndroidQF will:
 - Check for known spyware indicators
 - Extract system information
 - Generate a report
-
-!!! tip "Installing AndroidQF"
-    If you don't have AndroidQF installed, see the [AndroidQF documentation](https://github.com/mvt-project/androidqf) for installation instructions.
 
 ## Verification Checklist
 
@@ -251,8 +248,7 @@ ps aux | grep mesh
 meshcli status
 
 # Try reconnecting
-meshcli down
-meshcli up --login-server=https://your-domain.com --authkey=YOUR_KEY
+docker compose restart analyst
 ```
 
 **On control plane:**

--- a/docs/setup/verification.md
+++ b/docs/setup/verification.md
@@ -35,17 +35,17 @@ You should see:
 Test basic network connectivity to the Android device:
 
 ```bash
-ping 100.64.2.1
+ping 100.64.0.2
 ```
 
-Replace `100.64.2.1` with your Android device's actual mesh IP address.
+Replace `100.64.0.2` with your Android device's actual mesh IP address.
 
 **Example output:**
 
 ```
-PING 100.64.2.1 (100.64.2.1) 56(84) bytes of data.
-64 bytes from 100.64.2.1: icmp_seq=1 ttl=64 time=45.2 ms
-64 bytes from 100.64.2.1: icmp_seq=2 ttl=64 time=42.8 ms
+PING 100.64.0.2 (100.64.0.2) 56(84) bytes of data.
+64 bytes from 100.64.0.2: icmp_seq=1 ttl=64 time=45.2 ms
+64 bytes from 100.64.0.2: icmp_seq=2 ttl=64 time=42.8 ms
 ```
 
 !!! tip "High Latency?"
@@ -71,15 +71,19 @@ The Android device should automatically enable ADB-over-WiFi on its mesh IP. Let
 ### Connect to the Device
 
 ```bash
-adb connect 100.64.2.1:5555
+meshcli adbpair --host 100.64.0.2 --hostport 1234 --pairport 4321 --code 123456
 ```
 
-Replace `100.64.2.1` with your Android device's mesh IP.
+Replace `100.64.0.2` with your Android device's mesh IP.
 
 **Example output:**
 
 ```
-connected to 100.64.2.1:5555
+ADB pair successful, now connecting...
+ADB connect successful:
+connected to 100.64.0.2:1234
+Validating ADB session...
+Success! Device connected
 ```
 
 ### Verify ADB Connection
@@ -92,7 +96,7 @@ adb devices
 
 ```
 List of devices attached
-100.64.2.1:5555    device
+100.64.0.2:1234    device
 ```
 
 !!! success "ADB Connected"
@@ -220,20 +224,20 @@ docker compose logs headscale | grep DERP
 
 1. Verify ADB is enabled in the MESH app on Android
 2. Check the mesh IP address is correct
-3. Ensure port 5555 is not blocked
+3. Ensure wireless debugging port is not blocked
 
 **Error: "Connection timed out"**
 
 1. Verify the Android device is online in the mesh
 2. Try pinging the device first
-3. Check if the device's firewall is blocking port 5555
+3. Check if the device's firewall is blocking wireless debugging port
 
 **Fix: Restart ADB**
 
 ```bash
 adb kill-server
 adb start-server
-adb connect 100.64.2.1:5555
+adb connect 100.64.0.2:1234
 ```
 
 ### No Devices Showing in Mesh

--- a/docs/user-guide/architecture.md
+++ b/docs/user-guide/architecture.md
@@ -110,7 +110,7 @@ The endpoint client runs on the target device being analysed. Currently supports
 **Key features:**
 
 - One-tap connection to mesh
-- ADB-over-WiFi guiudance
+- ADB-over-WiFi guidance
 - Ephemeral mode (disconnect on app close)
 - Battery optimization
 - Network usage monitoring

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -54,7 +54,7 @@ meshcli status
 meshcli ping 100.64.x.x
 
 # Capture network traffic
-sudo tcpdump -i tailscale0 -w capture.pcap
+tcpdump -i tailscale0 -w capture.pcap
 ```
 
 ## Getting Help

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -39,10 +39,10 @@ This section covers:
 
 ```bash
 #Connect and pair to an Android device over ADB-over-Wifi
-meshcli adbpair --host 100.63.x.x --hostport 1234 --pairport 1234 --code 1234
+meshcli adbpair --host 100.64.x.x --hostport 1234 --pairport 4321 --code 123456
 
-#Connect and pair BUT initate AndroidQF instantly on connection
-meshcli adbpair --host 100.63.x.x --hostport 1234 --pairport 1234 --code 1234 --qf
+#Connect and pair BUT initiate AndroidQF instantly on connection
+meshcli adbpair --host 100.64.x.x --hostport 1234 --pairport 4321 --code 123456 --qf
 
 #Initate ADB acquisition using AndroidQF and WARD libraries
 meshcli adbcollect
@@ -51,13 +51,7 @@ meshcli adbcollect
 meshcli status
 
 # Test connection and establish UDP hole punching
-meshcli ping 100.67.x.x
-
-# Connect to Android device
-adb connect 100.64.x.x:5555
-
-# Run AndroidQF scan
-androidqf --adb 100.64.x.x:5555 --output ./artifacts/
+meshcli ping 100.64.x.x
 
 # Capture network traffic
 sudo tcpdump -i mesh0 -w capture.pcap

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -54,7 +54,7 @@ meshcli status
 meshcli ping 100.64.x.x
 
 # Capture network traffic
-sudo tcpdump -i mesh0 -w capture.pcap
+sudo tcpdump -i tailscale0 -w capture.pcap
 ```
 
 ## Getting Help

--- a/docs/user-guide/user-guide.md
+++ b/docs/user-guide/user-guide.md
@@ -19,8 +19,7 @@ This guide covers common forensic workflows and best practices for using MESH in
 3. **Establish ADB connection**
 
    ```bash
-   adb connect 100.64.X.X:5555
-   adb devices
+   meshcli adbpair --host 100.64.X.X --hostport 1234 --pairport 4321 --code 123456
    ```
 
 4. **Collect artifacts & run analysis**
@@ -30,7 +29,6 @@ This guide covers common forensic workflows and best practices for using MESH in
 5. **Tear down**
 
    ```bash
-   adb disconnect
    meshcli down
    ```
 
@@ -43,7 +41,7 @@ For operations in censored environments:
    **Analyst:**
 
    ```bash
-   sudo cat > /etc/mesh/amneziawg.conf << 'EOF'
+   docker compose exec analyst tee /etc/mesh/amneziawg.conf >/dev/null << 'EOF'
    [Interface]
    Jc = 10
    Jmin = 50

--- a/docs/user-guide/user-guide.md
+++ b/docs/user-guide/user-guide.md
@@ -78,21 +78,21 @@ Multiple analysts investigating multiple devices:
 
 1. **Set up ACLs**
 
-   ```yaml
-   groups:
-     group:analysts:
-       - analyst1
-       - analyst2
-     group:endpoints:
-       - device1
-       - device2
-   
-   acls:
-     - action: accept
-       src:
-         - group:analysts
-       dst:
-         - group:endpoints:*
+   ```json
+   {
+      "groups": {
+         "group:analysts": ["analyst1", "analyst2", "analyst3"],
+         "group:endpoints": ["phone1", "phone2", "phone3"]
+      },
+
+      "acls": [
+         {
+            "action": "accept",
+            "src": ["group:analysts"],
+            "dst": ["group:endpoints:*"]
+         }
+      ]
+   }
    ```
 
 2. **Assign devices**
@@ -149,20 +149,23 @@ Block all non-MESH traffic on endpoint:
 
 ### Exit nodes for Network Capture
 
-Route internet traffic through an endpoint:
+Route the endpoint's internet traffic through the analyst node so the analyst can capture it.
 
 **On analyst:**
 
 ```bash
-# Use endpoint as exit node
-meshcli up --exit-node=100.64.X.X
+# Advertise this node as an exit node
+meshcli up --advertise-exit-node
 
-# Verify
-curl ifconfig.me  # Should show endpoint's public IP
-
-# Stop using exit node
-meshcli up --exit-node=
+# Or, if already connected, toggle the setting
+meshcli set --advertise-exit-node
 ```
+
+**In the control plane Web UI:**
+
+1. Open the home page and expand the network containing the analyst node.
+2. Click the **APPROVE EXIT** button on the analyst node's row.
+3. Confirm the prompt.
 
 **On endpoint:**
 
@@ -170,11 +173,19 @@ meshcli up --exit-node=
 2. Settings > Use 100.64.x.x as exit node
 3. Enable
 
+**Verify on the endpoint:** outbound traffic should now route to the internet from the analyst's public IP.
+
+**Capture on the analyst:**
+
+```bash
+tcpdump -i tailscale0 -w capture.pcap
+```
+
 **Use cases:**
 
 - Monitor endpoint's internet traffic and capture traffic
-- Access geo-restricted content
 - Investigate network-level issues
+- Build a forensic record of network activity
 
 ### Operational
 
@@ -221,8 +232,8 @@ DEVICE_IP="100.64.X.X"
 OUTPUT_DIR="./artifacts/$(date +%Y%m%d-%H%M%S)"
 mkdir -p "$OUTPUT_DIR"
 
-# Connect
-adb connect $DEVICE_IP:5555
+# Pair and connect over the mesh
+meshcli adbpair $DEVICE_IP:5555
 
 # Bug report
 adb bugreport "$OUTPUT_DIR/bugreport.zip"
@@ -246,7 +257,7 @@ adb shell netstat > "$OUTPUT_DIR/netstat.txt"
 adb shell getprop > "$OUTPUT_DIR/properties.txt"
 
 # AndroidQF
-androidqf --adb $DEVICE_IP:5555 --output "$OUTPUT_DIR/androidqf/"
+meshcli adbcollect --output "$OUTPUT_DIR/androidqf/"
 
 # Disconnect
 adb disconnect

--- a/docs/user-guide/user-guide.md
+++ b/docs/user-guide/user-guide.md
@@ -14,7 +14,7 @@ This guide covers common forensic workflows and best practices for using MESH in
 2. **Connect devices**
    - Start MESH daemon on analyst workstation
    - Connect endpoint device to mesh
-   - Verify connectivity with `meshcli status --peers`
+   - Verify connectivity with `meshcli status`
 
 3. **Establish ADB connection**
 
@@ -55,7 +55,7 @@ For operations in censored environments:
    H3 = 3456789
    H4 = 4567890
    EOF
-   sudo systemctl restart mesh
+   docker compose restart analyst
    ```
 
    **Endpoint:**
@@ -203,11 +203,8 @@ meshcli up --exit-node=
 ### Checking Connection Status
 
 ```bash
-# Basic status
+# Basic peer status
 meshcli status
-
-# Detailed peer information
-meshcli status --peers
 
 # JSON output for scripting
 meshcli status --json | jq
@@ -263,10 +260,10 @@ echo "Collection complete: $OUTPUT_DIR"
 
 ```bash
 # List all connected devices
-meshcli status --peers | grep -E "100\.64\."
+meshcli status | grep -E "100\.64\."
 
 # Connect to all devices
-for ip in $(meshcli status --peers | grep -oE "100\.64\.[0-9]+\.[0-9]+"); do
+for ip in $(meshcli status | grep -oE "100\.64\.[0-9]+\.[0-9]+"); do
     adb connect $ip:5555
 done
 
@@ -279,27 +276,23 @@ adb disconnect
 
 ### Automating investigations
 
+The analyst container's entrypoint reads `LOGIN_URL` and `AUTH_KEY` from `.env` and starts the MESH daemon for you. From the analyst workstation, run meshcli subcommands via `docker compose exec`.
+
 ```bash
 #!/bin/bash
 # auto-investigate.sh
 
-CONTROL_PLANE="https://mesh.yourdomain.com"
-PREAUTH_KEY="your-key-here"
-
-# Start daemon
-sudo systemctl start mesh
-
-# Connect to control plane
-meshcli up --login-server=$CONTROL_PLANE --authkey=$PREAUTH_KEY --accept-dns=false
+# Make sure LOGIN_URL and AUTH_KEY are set in .env before running, then start the analyst container:
+task analyst
 
 # Wait for peers
 echo "Waiting for devices..."
-while [ $(meshcli status --peers | grep -c "100.64") -eq 0 ]; do
+while [ $(docker compose exec analyst mesh cli status | grep -c "100.64") -eq 0 ]; do
     sleep 5
 done
 
 # Get device IPs
-DEVICES=$(meshcli status --peers | grep -oE "100\.64\.[0-9]+\.[0-9]+")
+DEVICES=$(docker compose exec analyst mesh cli status | grep -oE "100\.64\.[0-9]+\.[0-9]+")
 
 # Investigate each device
 for device in $DEVICES; do
@@ -308,7 +301,7 @@ for device in $DEVICES; do
 done
 
 # Disconnect
-meshcli down
+docker compose down analyst
 
 echo "Investigation complete"
 ```


### PR DESCRIPTION
## Summary

Fixes a number of issues with out-of-date or inaccurate documentation:

- `--authkey` -> `--auth-key`
- `docker ps` / `docker logs` -> `docker compose ps` / `docker compose logs`
- `cat config/acl.yaml` -> `docker compose exec headscale headscale policy get`
- `meshcli status --peers` -> `meshcli status` (flag is default-true so does nothing)
- `/health` returns `pass`, not `ok`
- Drop `sudo` on commands run inside the analyst container since it already runs as root
- AmneziaWG conf heredoc writes inside the container, not on the host
- Example mesh IPs use `100.64.0.1` / `100.64.0.2`
- Drop hardcoded ADB port `5555`; pair/connect via `meshcli adbpair` flags
- other misc fixes like file paths, missing flags, broken cross-references

## Documentation

- [ ] No documentation updates needed
- [x] README / docs updated
- [x] User, analyst, or operator-facing changes documented

## Reviewer guidance

Stacked on top of #117, so that should be merged first.