### PR TITLE
fix: regression on controlplane config

### DIFF
--- a/control-plane/headscale/config.example.yaml
+++ b/control-plane/headscale/config.example.yaml
@@ -74,7 +74,7 @@ derp:
   server:
     # If enabled, runs the embedded DERP server and merges it into the rest of the DERP config
     # The Headscale server_url defined above MUST be using https, DERP requires TLS to be in place
-    enabled: true
+    enabled: false
 
     # Region ID to use for the embedded DERP server.
     # The local DERP prevails if the region ID collides with other region ID coming from
@@ -109,7 +109,8 @@ derp:
 
   # List of externally available DERP maps encoded in JSON
   # Set to empty list to disable Tailscale's built-in DERP servers
-  urls: []
+  urls:
+    - https://controlplane.tailscale.com/derpmap/default
 
   # Locally available DERP map files encoded in YAML
   #


### PR DESCRIPTION
Regression fix caused on.
The original intention for the PR was to remove NETMAP on the apk calling out to derps on boot. this regression stripped out all DERP maps on the control plane too, which was not necessary. Default option is to use tailscale's DERP relays and selfhosting is a secondary option. By flipping that, users have to set up their own derp as a requirement for it to work out of the box. 

https://github.com/BARGHEST-ngo/MESH/pull/93 