### PR TITLE
Fix/manifest export

### DIFF
--- a/android-client/android/src/main/AndroidManifest.xml
+++ b/android-client/android/src/main/AndroidManifest.xml
@@ -99,13 +99,7 @@
 
         <receiver
             android:name="IPNReceiver"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="com.tailscale.ipn.CONNECT_VPN" />
-                <action android:name="com.tailscale.ipn.DISCONNECT_VPN" />
-                <action android:name="com.tailscale.ipn.USE_EXIT_NODE" />
-            </intent-filter>
-        </receiver>
+            android:exported="false" />
 
         <receiver
             android:name=".MDMSettingsChangedReceiver"

--- a/android-client/android/src/main/java/com/barghest/mesh/IPNReceiver.java
+++ b/android-client/android/src/main/java/com/barghest/mesh/IPNReceiver.java
@@ -25,10 +25,10 @@ import java.util.Objects;
  */
 public class IPNReceiver extends BroadcastReceiver {
 
-    public static final String INTENT_CONNECT_VPN = "com.barghest.com.barghest.com.barghest.com.barghest.mesh.CONNECT_VPN";
-    public static final String INTENT_DISCONNECT_VPN = "com.barghest.com.barghest.com.barghest.com.barghest.mesh.DISCONNECT_VPN";
+    public static final String INTENT_CONNECT_VPN = "com.barghest.mesh.CONNECT_VPN";
+    public static final String INTENT_DISCONNECT_VPN = "com.barghest.mesh.DISCONNECT_VPN";
 
-    private static final String INTENT_USE_EXIT_NODE = "com.barghest.com.barghest.com.barghest.com.barghest.mesh.USE_EXIT_NODE";
+    private static final String INTENT_USE_EXIT_NODE = "com.barghest.mesh.USE_EXIT_NODE";
 
     @Override
     public void onReceive(Context context, Intent intent) {


### PR DESCRIPTION
- IPN receiver was there for MDM's to remove the VPN if they need. not applicable for our usecase
- duplicate constants in broadcast receiver probs dodgy find and replace.