### PR TITLE
feat: add reset action to clear all profile states

### DIFF
--- a/android-client/android/src/main/java/com/barghest/mesh/ui/localapi/Client.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/localapi/Client.kt
@@ -166,6 +166,10 @@ class Client(private val scope: CoroutineScope) {
     get(Endpoint.FILE_TARGETS, responseHandler = responseHandler)
   }
 
+  fun resetAuth(responseHandler: (Result<Unit>) -> Unit) {
+      return post(Endpoint.RESET_AUTH, responseHandler = responseHandler)
+  }
+
   fun putTaildropFiles(
       context: Context,
       peerId: StableNodeID,

--- a/android-client/android/src/main/java/com/barghest/mesh/ui/view/ErrorDialog.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/view/ErrorDialog.kt
@@ -26,7 +26,8 @@ enum class ErrorDialogType {
   ADD_PROFILE_FAILED,
   SHARE_DEVICE_NOT_CONNECTED,
   SHARE_FAILED,
-  INVALID_AUTH_KEY;
+  INVALID_AUTH_KEY,
+  RESET_FAILED;
 
   val message: Int
     get() {
@@ -38,6 +39,7 @@ enum class ErrorDialogType {
         SHARE_DEVICE_NOT_CONNECTED -> R.string.share_device_not_connected
         SHARE_FAILED -> R.string.taildrop_share_failed
         INVALID_AUTH_KEY -> R.string.invalidAuthKey
+        RESET_FAILED -> R.string.reset_failed
       }
     }
 
@@ -51,6 +53,7 @@ enum class ErrorDialogType {
         SHARE_DEVICE_NOT_CONNECTED -> R.string.share_device_not_connected_title
         SHARE_FAILED -> R.string.taildrop_share_failed_title
         INVALID_AUTH_KEY -> R.string.invalidAuthKeyTitle
+        RESET_FAILED -> R.string.reset_failed_title
       }
     }
 

--- a/android-client/android/src/main/java/com/barghest/mesh/ui/view/UserSwitcherView.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/view/UserSwitcherView.kt
@@ -15,12 +15,20 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -50,10 +58,41 @@ fun UserSwitcherView(nav: UserSwitcherNav, viewModel: UserSwitcherViewModel = vi
             modifier = Modifier.padding(innerPadding).fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(8.dp)) {
               val showErrorDialog by viewModel.errorDialog.collectAsState()
+              var showResetConfirm by remember { mutableStateOf(false) }
 
               // Show the error overlay if need be
               showErrorDialog?.let {
                 ErrorDialog(type = it, action = { viewModel.errorDialog.set(null) })
+              }
+
+              // Confirm before resetting as it erases keys/profiles/prefs
+              if (showResetConfirm) {
+                AlertDialog(
+                    onDismissRequest = { showResetConfirm = false },
+                    title = { Text(stringResource(R.string.reset_mesh_confirm_title)) },
+                    text = { Text(stringResource(R.string.reset_mesh_confirm_message)) },
+                    confirmButton = {
+                      TextButton(
+                          onClick = {
+                            showResetConfirm = false
+                            viewModel.resetAuth { result ->
+                              result
+                                  .onSuccess { nav.onNavigateHome() }
+                                  .onFailure {
+                                    viewModel.errorDialog.set(ErrorDialogType.RESET_FAILED)
+                                  }
+                            }
+                          }) {
+                            Text(
+                                stringResource(R.string.reset),
+                                color = MaterialTheme.colorScheme.error)
+                          }
+                    },
+                    dismissButton = {
+                      TextButton(onClick = { showResetConfirm = false }) {
+                        Text(stringResource(R.string.cancel))
+                      }
+                    })
               }
 
               LazyColumn {
@@ -73,6 +112,13 @@ fun UserSwitcherView(nav: UserSwitcherNav, viewModel: UserSwitcherViewModel = vi
                         })
                     Lists.ItemDivider()
                   }
+
+                  Setting.Text(
+                      R.string.reset_mesh,
+                      subtitle = stringResource(R.string.reset_mesh_subtitle),
+                      destructive = true,
+                      onClick = { showResetConfirm = true })
+                  Lists.ItemDivider()
                 }
               }
             }

--- a/android-client/android/src/main/java/com/barghest/mesh/ui/viewModel/IpnViewModel.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/viewModel/IpnViewModel.kt
@@ -204,6 +204,21 @@ open class IpnViewModel : ViewModel() {
     }
   }
 
+  fun resetAuth(completionHandler: (Result<Unit>) -> Unit = {}) {
+      Client(viewModelScope).resetAuth { 
+          result -> result
+          .onSuccess {
+              TSLog.d(TAG, "Auth state reset")
+              completionHandler(Result.success(Unit))
+              stopVPN()
+          }
+          .onFailure {
+              TSLog.d(TAG, "Error resetting auth state: ${it.message}")
+              completionHandler(Result.failure(it))
+          }
+      }
+  }
+
   fun loginWithAuthKey(authKey: String, completionHandler: (Result<Unit>) -> Unit = {}) {
     val prefs = Ipn.MaskedPrefs()
     prefs.WantRunning = true

--- a/android-client/android/src/main/res/values/strings.xml
+++ b/android-client/android/src/main/res/values/strings.xml
@@ -430,4 +430,13 @@
     <string name="awg_validation_error">Invalid configuration</string>
     <string name="awg_restart_required">Settings saved. Disconnect and reconnect to apply changes.</string>
 
+    <!-- Reset auth -->
+    <string name="reset_mesh">Reset MESH</string>
+    <string name="reset_mesh_subtitle">Clear keys, profiles &amp; preferences; keeps app data</string>
+    <string name="reset_mesh_confirm_title">Reset MESH?</string>
+    <string name="reset_mesh_confirm_message">This erases all node keys, control planes profiles, and preferences on this device and disconnects the tunnel. Downloaded files and app data are kept. You\'ll need to log in again.</string>
+    <string name="reset">Reset</string>
+    <string name="reset_failed">Unable to reset MESH at this time. Please try again.</string>
+    <string name="reset_failed_title">Reset failed</string>
+
 </resources>


### PR DESCRIPTION
- The logout button is the happy path when the control plane is reachable. it tells the control plane the device is leaving so the node is properly deregistered. The issue is that this depends on reaching the control plane and so if it's unreachable, we have no way to clearning the device state  without clearing app cash
- this feature provide an option to reset all auth states locally without control plane
- removes keys, pref, control planes and profiles