### PR TITLE
refactor: overhall mesh UI to new wireframe

### DIFF
--- a/android-client/android/src/main/java/com/barghest/mesh/ui/Links.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/Links.kt
@@ -15,6 +15,8 @@ object Links {
   const val SERVER_URL = ""
   const val ADMIN_URL = SERVER_URL + "/admin"
   const val SIGNIN_URL = ""
+  const val SOURCE_REPO_URL = "https://github.com/BARGHEST-ngo/MESH"
+  const val LICENSE_URL = "https://github.com/BARGHEST-ngo/MESH/blob/main/LICENSE"
   const val PRIVACY_POLICY_URL = "https://barghest.asia/mesh/priv"
   const val TERMS_URL = "https://barghest.asia/mesh/terms"
   const val DOCS_URL = "https://barghest.asia/mesh/docs"

--- a/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshAdbSetup.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshAdbSetup.kt
@@ -1,0 +1,171 @@
+// Copyright (c) BARGHEST
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.barghest.mesh.ui.view.mesh
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.barghest.mesh.ui.theme.MeshMono
+import com.barghest.mesh.ui.theme.MeshRadii
+import com.barghest.mesh.ui.theme.accent
+import com.barghest.mesh.ui.theme.accentDim
+import com.barghest.mesh.ui.theme.meshAmber
+import com.barghest.mesh.ui.theme.meshAmberDim
+import com.barghest.mesh.ui.theme.meshBg
+import com.barghest.mesh.ui.theme.meshBorder
+import com.barghest.mesh.ui.theme.meshCard
+import com.barghest.mesh.ui.theme.meshGreen
+import com.barghest.mesh.ui.theme.meshText
+import com.barghest.mesh.ui.theme.meshText2
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import com.barghest.mesh.R
+
+private data class AdbStep(val n: Int, val title: String, val body: String)
+
+/** Opens Developer options (Wireless debugging), falling back to the top-level Settings app. */
+private fun openDeveloperSettings(context: Context) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+        Toast.makeText(context, context.getString(R.string.mesh_adb_toast_need_r), Toast.LENGTH_LONG).show()
+    }
+    val intents = listOf(
+        Intent(Settings.ACTION_APPLICATION_DEVELOPMENT_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+        Intent(Settings.ACTION_SETTINGS).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK),
+    )
+    for (intent in intents) {
+        if (context.packageManager.resolveActivity(intent, 0) != null) {
+            context.startActivity(intent)
+            if (intent.action == Settings.ACTION_SETTINGS) {
+                Toast.makeText(context, context.getString(R.string.mesh_adb_toast_navigate), Toast.LENGTH_LONG).show()
+            }
+            return
+        }
+    }
+    Toast.makeText(context, context.getString(R.string.mesh_adb_toast_unable), Toast.LENGTH_LONG).show()
+}
+
+@Composable
+fun MeshAdbSetupScreen(
+    onBack: () -> Unit,
+    onEnabled: () -> Unit,
+) {
+    val cs = MaterialTheme.colorScheme
+    val context = LocalContext.current
+    var done by remember { mutableStateOf(setOf<Int>()) }
+    val steps = listOf(
+        AdbStep(1, stringResource(R.string.mesh_adb_s1_title), stringResource(R.string.mesh_adb_s1_body)),
+        AdbStep(2, stringResource(R.string.mesh_adb_s2_title), stringResource(R.string.mesh_adb_s2_body)),
+        AdbStep(3, stringResource(R.string.mesh_adb_s3_title), stringResource(R.string.mesh_adb_s3_body)),
+        AdbStep(4, stringResource(R.string.mesh_adb_s4_title), stringResource(R.string.mesh_adb_s4_body)),
+        AdbStep(5, stringResource(R.string.mesh_adb_s5_title), stringResource(R.string.mesh_adb_s5_body)),
+    )
+
+    Column(Modifier.fillMaxSize().background(cs.meshBg)) {
+        MeshTopBar(stringResource(R.string.mesh_adb_topbar), onBack = onBack)
+        Column(Modifier.weight(1f).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp)) {
+            Spacer(Modifier.height(18.dp))
+            Text(stringResource(R.string.mesh_adb_title), color = cs.meshText, fontSize = 21.sp, fontWeight = FontWeight.SemiBold, letterSpacing = (-0.3).sp)
+            Spacer(Modifier.height(6.dp))
+            Text(
+                stringResource(R.string.mesh_adb_intro),
+                color = cs.meshText2, fontSize = 13.5.sp, lineHeight = 20.sp,
+            )
+            Spacer(Modifier.height(16.dp))
+
+            Callout("info", cs.accent, cs.accentDim(0.08f), cs.accentDim(0.25f),
+                stringResource(R.string.mesh_adb_callout_menus))
+            Spacer(Modifier.height(18.dp))
+
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                steps.forEach { s ->
+                    val ok = s.n in done
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .background(cs.meshCard, RoundedCornerShape(MeshRadii.card))
+                            .border(1.dp, if (ok) cs.meshGreen.copy(alpha = 0.4f) else cs.meshBorder, RoundedCornerShape(MeshRadii.card))
+                            .clickable { done = if (ok) done - s.n else done + s.n }
+                            .padding(14.dp),
+                        horizontalArrangement = Arrangement.spacedBy(13.dp),
+                        verticalAlignment = Alignment.Top,
+                    ) {
+                        Box(
+                            Modifier.size(28.dp).background(if (ok) cs.meshGreen else cs.accentDim(0.16f), RoundedCornerShape(9.dp)),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            if (ok) MeshIcon("check", size = 16.dp, color = Color(0xFF0C0D0F), stroke = 2.4f)
+                            else Text("${s.n}", color = cs.accent, fontFamily = MeshMono, fontSize = 13.sp, fontWeight = FontWeight.Bold)
+                        }
+                        Column(Modifier.weight(1f)) {
+                            Text(s.title, color = cs.meshText, fontSize = 14.5.sp, fontWeight = FontWeight.SemiBold)
+                            Spacer(Modifier.height(2.dp))
+                            Text(s.body, color = cs.meshText2, fontSize = 12.5.sp, lineHeight = 18.sp)
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(16.dp))
+            Callout("alert", cs.meshAmber, cs.meshAmberDim, cs.meshAmber.copy(alpha = 0.3f),
+                stringResource(R.string.mesh_adb_callout_warn))
+            Spacer(Modifier.height(20.dp))
+        }
+
+        Column(Modifier.fillMaxWidth().background(cs.meshBg)) {
+            Box(Modifier.fillMaxWidth().height(1.dp).background(cs.meshBorder))
+            Row(Modifier.padding(horizontal = 20.dp, vertical = 14.dp), horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                MeshButton(stringResource(R.string.mesh_adb_open_settings), { openDeveloperSettings(context) }, modifier = Modifier.weight(1f), variant = MeshButtonVariant.Secondary, height = 56.dp)
+                MeshButton(stringResource(R.string.mesh_adb_its_on), onEnabled, modifier = Modifier.weight(1f), height = 56.dp, icon = "check")
+            }
+        }
+    }
+}
+
+@Composable
+private fun Callout(icon: String, iconColor: Color, bg: Color, border: Color, text: String) {
+    val cs = MaterialTheme.colorScheme
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .background(bg, RoundedCornerShape(12.dp))
+            .border(1.dp, border, RoundedCornerShape(12.dp))
+            .padding(13.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        MeshIcon(icon, size = 17.dp, color = iconColor, modifier = Modifier.padding(top = 1.dp))
+        Text(text, color = cs.meshText2, fontSize = 12.5.sp, lineHeight = 19.sp)
+    }
+}

--- a/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshComponents.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshComponents.kt
@@ -1,0 +1,271 @@
+// Copyright (c) BARGHEST
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.barghest.mesh.ui.view.mesh
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.barghest.mesh.ui.theme.MeshMono
+import com.barghest.mesh.ui.theme.MeshRadii
+import com.barghest.mesh.ui.theme.accent
+import com.barghest.mesh.ui.theme.accentDim
+import com.barghest.mesh.ui.theme.dim
+import com.barghest.mesh.ui.theme.meshBgRaised
+import com.barghest.mesh.ui.theme.meshBorder
+import com.barghest.mesh.ui.theme.meshBorderHi
+import com.barghest.mesh.ui.theme.meshCard
+import com.barghest.mesh.ui.theme.meshCardHi
+import com.barghest.mesh.ui.theme.meshMonoText
+import com.barghest.mesh.ui.theme.meshMuted
+import com.barghest.mesh.ui.theme.meshRed
+import com.barghest.mesh.ui.theme.meshRedDim
+import com.barghest.mesh.ui.theme.meshText
+import com.barghest.mesh.ui.theme.meshText2
+
+/** Status dot with an optional pulsing halo. */
+@Composable
+fun StatusDot(color: Color, size: Dp = 9.dp, pulse: Boolean = false) {
+    Box(contentAlignment = Alignment.Center, modifier = Modifier.size(size)) {
+        if (pulse) {
+            val t = rememberInfiniteTransition(label = "dotPulse")
+            val scale by t.animateFloat(
+                initialValue = 1f, targetValue = 2.6f,
+                animationSpec = infiniteRepeatable(tween(1800), RepeatMode.Restart), label = "scale",
+            )
+            val fade by t.animateFloat(
+                initialValue = 0.5f, targetValue = 0f,
+                animationSpec = infiniteRepeatable(tween(1800), RepeatMode.Restart), label = "fade",
+            )
+            Box(
+                Modifier
+                    .size(size)
+                    .graphicsLayer { scaleX = scale; scaleY = scale; alpha = fade }
+                    .clip(CircleShape)
+                    .background(color),
+            )
+        }
+        Box(Modifier.size(size).clip(CircleShape).background(color))
+    }
+}
+
+@Composable
+fun Eyebrow(text: String, modifier: Modifier = Modifier, color: Color = MaterialTheme.colorScheme.meshMuted) {
+    Text(
+        text = text,
+        modifier = modifier,
+        fontFamily = MaterialTheme.typography.bodyMedium.fontFamily,
+        fontSize = 12.sp,
+        fontWeight = FontWeight.SemiBold,
+        letterSpacing = 0.2.sp,
+        color = color,
+    )
+}
+
+/** Shared card surface: rounded clip + fill + hairline border. */
+fun Modifier.meshCard(
+    shape: androidx.compose.ui.graphics.Shape,
+    fill: Color,
+    border: Color,
+): Modifier = clip(shape).background(fill).border(1.dp, border, shape)
+
+@Composable
+fun MeshCard(
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    pad: Dp = 16.dp,
+    content: @Composable () -> Unit,
+) {
+    val shape = RoundedCornerShape(MeshRadii.card)
+    var base = modifier.meshCard(shape, MaterialTheme.colorScheme.meshCard, MaterialTheme.colorScheme.meshBorder)
+    if (onClick != null) base = base.clickable(onClick = onClick)
+    Box(base.padding(pad)) { content() }
+}
+
+enum class MeshButtonVariant { Primary, Secondary, Ghost, Danger }
+
+@Composable
+fun MeshButton(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    variant: MeshButtonVariant = MeshButtonVariant.Primary,
+    full: Boolean = false,
+    icon: String? = null,
+    height: Dp = 52.dp,
+    enabled: Boolean = true,
+) {
+    val cs = MaterialTheme.colorScheme
+    val shape = RoundedCornerShape(MeshRadii.md)
+    val (bg, fg, borderColor) = when (variant) {
+        MeshButtonVariant.Primary -> Triple(cs.accent, Color.White, Color.Transparent)
+        MeshButtonVariant.Secondary -> Triple(cs.meshCard, cs.meshText, cs.meshBorderHi)
+        MeshButtonVariant.Ghost -> Triple(Color.Transparent, cs.meshText2, cs.meshBorder)
+        MeshButtonVariant.Danger -> Triple(cs.meshRedDim, cs.meshRed, cs.meshRed)
+    }
+    var m = modifier
+        .then(if (full) Modifier.fillMaxWidth() else Modifier)
+        .height(height)
+        .clip(shape)
+        .background(bg)
+        .border(1.dp, borderColor, shape)
+        .alpha(if (enabled) 1f else 0.45f)
+    if (enabled) m = m.clickable(onClick = onClick)
+    Row(
+        modifier = m.padding(horizontal = 20.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        if (icon != null) {
+            MeshIcon(icon, size = 18.dp, color = fg)
+            Spacer(Modifier.width(9.dp))
+        }
+        Text(text, color = fg, fontSize = 15.5.sp, fontWeight = FontWeight.SemiBold)
+    }
+}
+
+@Composable
+fun MeshChip(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = MaterialTheme.colorScheme.meshText2,
+    bg: Color = MaterialTheme.colorScheme.meshBgRaised,
+    border: Color = MaterialTheme.colorScheme.meshBorder,
+    icon: String? = null,
+) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(MeshRadii.pill))
+            .background(bg)
+            .border(1.dp, border, RoundedCornerShape(MeshRadii.pill))
+            .padding(horizontal = 9.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp),
+    ) {
+        if (icon != null) MeshIcon(icon, size = 12.dp, color = color)
+        Text(text, color = color, fontSize = 11.sp, fontWeight = FontWeight.SemiBold, letterSpacing = 0.2.sp)
+    }
+}
+
+/** Eyebrow + title + sub; the eyebrow is hidden when it would just echo the title. */
+@Composable
+fun SectionHead(
+    title: String? = null,
+    eyebrow: String? = null,
+    sub: String? = null,
+    action: (@Composable () -> Unit)? = null,
+) {
+    val cs = MaterialTheme.colorScheme
+    val showEyebrow = eyebrow != null &&
+        (title == null || !eyebrow.equals(title, ignoreCase = true))
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(bottom = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.Top,
+    ) {
+        Column(Modifier.weight(1f)) {
+            if (showEyebrow) {
+                Eyebrow(eyebrow!!)
+                Spacer(Modifier.height(6.dp))
+            }
+            if (title != null) {
+                Text(title, color = cs.meshText, fontSize = 16.sp, fontWeight = FontWeight.SemiBold, letterSpacing = (-0.1).sp)
+            }
+            if (sub != null) {
+                Spacer(Modifier.height(3.dp))
+                Text(sub, color = cs.meshText2, fontSize = 13.sp, lineHeight = 18.sp)
+            }
+        }
+        if (action != null) {
+            Spacer(Modifier.width(12.dp))
+            action()
+        }
+    }
+}
+
+@Composable
+fun MeshTopBar(
+    label: String,
+    onBack: (() -> Unit)? = null,
+    action: (@Composable () -> Unit)? = null,
+) {
+    val cs = MaterialTheme.colorScheme
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(cs.background)
+            .padding(horizontal = 14.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        if (onBack != null) {
+            Box(
+                Modifier
+                    .size(38.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(cs.meshCard)
+                    .border(1.dp, cs.meshBorder, RoundedCornerShape(12.dp))
+                    .clickable(onClick = onBack),
+                contentAlignment = Alignment.Center,
+            ) { MeshIcon("chevL", size = 19.dp, color = cs.meshText2) }
+        } else {
+            Spacer(Modifier.width(6.dp))
+        }
+        Text(
+            label,
+            modifier = Modifier.weight(1f),
+            color = cs.meshText,
+            fontSize = 16.5.sp,
+            fontWeight = FontWeight.SemiBold,
+            letterSpacing = (-0.2).sp,
+        )
+        if (action != null) action()
+    }
+}
+
+/** Monospace technical value (IPs, byte counts, fingerprints). */
+@Composable
+fun MonoText(
+    text: String,
+    color: Color = MaterialTheme.colorScheme.meshMonoText,
+    fontSize: androidx.compose.ui.unit.TextUnit = 12.sp,
+    fontWeight: FontWeight = FontWeight.Normal,
+    modifier: Modifier = Modifier,
+) {
+    Text(text, modifier = modifier, color = color, fontFamily = MeshMono, fontSize = fontSize, fontWeight = fontWeight)
+}

--- a/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshFlow.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshFlow.kt
@@ -1,0 +1,112 @@
+// Copyright (c) BARGHEST
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.barghest.mesh.ui.view.mesh
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.barghest.mesh.ui.theme.meshBg
+
+private enum class MeshScreen { Home, Learn, Adb, Settings }
+
+/** Live backend wiring for the redesigned MESH client. */
+data class MeshLiveEnv(
+    val connected: Boolean,
+    val analyst: Analyst?,        // built from the netmap peer; null => placeholder
+    val controlUrl: String?,
+    val exitNodeName: String?,    // active exit node display name, or null = none
+    val onStartSession: () -> Unit,
+    val onEndSession: () -> Unit,
+    val onOpenExitNodes: () -> Unit,
+    val onOpenControlServer: () -> Unit,
+    val onOpenDns: () -> Unit,
+    val onOpenSplitTunnel: () -> Unit,
+    val onOpenObfuscation: () -> Unit,
+    val onForgetEnrollment: () -> Unit,
+)
+
+/** Host for the redesigned MESH client; [onExit] fires when backing out of the root. */
+@Composable
+fun MeshFlow(env: MeshLiveEnv, onExit: () -> Unit = {}) {
+    val cs = MaterialTheme.colorScheme
+    var screen by remember { mutableStateOf(MeshScreen.Home) }
+    var adbReady by remember { mutableStateOf(false) }
+    var endConfirm by remember { mutableStateOf(false) }
+
+    val connected = env.connected
+    val analyst = env.analyst ?: MeshSample.analyst
+
+    fun go(next: MeshScreen) {
+        screen = next
+    }
+
+    BackHandler(enabled = true) {
+        when (screen) {
+            MeshScreen.Home -> onExit()
+            else -> go(MeshScreen.Home)
+        }
+    }
+
+    val homeActions = MeshHomeActions(
+        onStart = { env.onStartSession() },
+        onEnd = { endConfirm = true },
+        onOpenSettings = { go(MeshScreen.Settings) },
+        onOpenLearn = { go(MeshScreen.Learn) },
+        onOpenExitNodes = { env.onOpenExitNodes() },
+        onOpenAdb = { go(MeshScreen.Adb) },
+    )
+
+    Column(Modifier.fillMaxSize().background(cs.meshBg)) {
+        Box(Modifier.weight(1f).fillMaxWidth().statusBarsPadding().navigationBarsPadding()) {
+            AnimatedContent(
+                targetState = screen,
+                transitionSpec = {
+                    // Crossfade — a slide re-records both screen trees each frame and janked.
+                    fadeIn(tween(140)) togetherWith fadeOut(tween(140))
+                },
+                label = "meshScreen",
+            ) { s ->
+                when (s) {
+                    MeshScreen.Home -> MeshHomeScreen(connected, homeActions, analyst = analyst, exitNodeName = env.exitNodeName, adbReady = adbReady)
+                    MeshScreen.Learn -> MeshLearnScreen(onBack = { go(MeshScreen.Home) }, onStart = { env.onStartSession() })
+                    MeshScreen.Adb -> MeshAdbSetupScreen(
+                        onBack = { go(MeshScreen.Home) },
+                        onEnabled = { adbReady = true; go(MeshScreen.Home) },
+                    )
+                    MeshScreen.Settings -> MeshSettingsScreen(
+                        onBack = { go(MeshScreen.Home) },
+                        live = MeshSettingsLive(
+                            controlUrl = env.controlUrl,
+                            onOpenControlServer = env.onOpenControlServer,
+                            onOpenExitNodes = env.onOpenExitNodes,
+                            onOpenDns = env.onOpenDns,
+                            onOpenSplitTunnel = env.onOpenSplitTunnel,
+                            onOpenObfuscation = env.onOpenObfuscation,
+                            onForgetEnrollment = env.onForgetEnrollment,
+                        ),
+                    )
+                }
+            }
+        }
+    }
+
+    if (endConfirm) MeshConfirmSheet(onCancel = { endConfirm = false }, onConfirm = { endConfirm = false; env.onEndSession() })
+}

--- a/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshHome.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshHome.kt
@@ -1,0 +1,389 @@
+// Copyright (c) BARGHEST
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.barghest.mesh.ui.view.mesh
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.StartOffset
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.rotate
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.barghest.mesh.R
+import com.barghest.mesh.ui.theme.MeshMono
+import com.barghest.mesh.ui.theme.accent
+import com.barghest.mesh.ui.theme.accentDim
+import com.barghest.mesh.ui.theme.dim
+import com.barghest.mesh.ui.theme.meshAmber
+import com.barghest.mesh.ui.theme.meshAmberDim
+import com.barghest.mesh.ui.theme.meshBg
+import com.barghest.mesh.ui.theme.meshBorder
+import com.barghest.mesh.ui.theme.meshCard
+import com.barghest.mesh.ui.theme.meshGreen
+import com.barghest.mesh.ui.theme.meshGreenDim
+import com.barghest.mesh.ui.theme.meshCyan
+import com.barghest.mesh.ui.theme.meshMonoText
+import com.barghest.mesh.ui.theme.meshMuted
+import com.barghest.mesh.ui.theme.meshText
+import com.barghest.mesh.ui.theme.meshText2
+import com.barghest.mesh.ui.util.AppVersion
+
+enum class HeroStyle { Rings, Shield, Bar }
+
+@Composable
+private fun HeroRings(active: Boolean) {
+    val cs = MaterialTheme.colorScheme
+    val c = if (active) cs.meshGreen else cs.meshMuted
+    Box(Modifier.size(188.dp), contentAlignment = Alignment.Center) {
+        if (active) {
+            val t = rememberInfiniteTransition(label = "rings")
+            repeat(3) { i ->
+                val scale by t.animateFloat(
+                    0.55f, 1.9f,
+                    infiniteRepeatable(tween(2800, easing = LinearEasing), RepeatMode.Restart, StartOffset(i * 900)),
+                    label = "rs$i",
+                )
+                val fade by t.animateFloat(
+                    0.9f, 0f,
+                    infiniteRepeatable(tween(2800, easing = LinearEasing), RepeatMode.Restart, StartOffset(i * 900)),
+                    label = "rf$i",
+                )
+                Box(
+                    Modifier
+                        .size(96.dp)
+                        .graphicsLayer { scaleX = scale; scaleY = scale; alpha = fade }
+                        .clip(CircleShape)
+                        .border(1.5.dp, c, CircleShape),
+                )
+            }
+            val rot by t.animateFloat(0f, 360f, infiniteRepeatable(tween(22000, easing = LinearEasing)), label = "rot")
+            Canvas(Modifier.size(150.dp)) {
+                rotate(rot) {
+                    drawCircle(
+                        color = c.copy(alpha = 0.4f),
+                        radius = size.minDimension / 2f,
+                        style = Stroke(1f.dp.toPx(), pathEffect = PathEffect.dashPathEffect(floatArrayOf(6f, 10f))),
+                    )
+                }
+            }
+        } else {
+            Canvas(Modifier.size(150.dp)) {
+                drawCircle(
+                    color = cs.meshBorder,
+                    radius = size.minDimension / 2f,
+                    style = Stroke(1f.dp.toPx(), pathEffect = PathEffect.dashPathEffect(floatArrayOf(6f, 10f))),
+                )
+            }
+        }
+        Box(
+            Modifier
+                .size(96.dp)
+                .clip(CircleShape)
+                .background(if (active) cs.meshGreen.dim(0.12f) else cs.meshCard)
+                .border(1.5.dp, if (active) cs.meshGreen else cs.meshBorder, CircleShape),
+            contentAlignment = Alignment.Center,
+        ) {
+            MeshIcon(if (active) "lock" else "shield", size = 40.dp, color = c, stroke = 1.6f)
+        }
+    }
+}
+
+@Composable
+private fun HeroBar(active: Boolean) {
+    val cs = MaterialTheme.colorScheme
+    val c = if (active) cs.meshGreen else cs.meshMuted
+    Column(Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 8.dp)) {
+        Box(
+            Modifier
+                .padding(bottom = 20.dp)
+                .size(64.dp)
+                .clip(RoundedCornerShape(16.dp))
+                .background(if (active) cs.meshGreen.dim(0.12f) else cs.meshCard)
+                .border(1.5.dp, if (active) cs.meshGreen else cs.meshBorder, RoundedCornerShape(16.dp))
+                .align(Alignment.CenterHorizontally),
+            contentAlignment = Alignment.Center,
+        ) { MeshIcon(if (active) "lock" else "shield", size = 30.dp, color = c) }
+        val t = rememberInfiniteTransition(label = "bars")
+        Row(Modifier.fillMaxWidth().height(8.dp), horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+            repeat(28) { i ->
+                val h by t.animateFloat(
+                    0.4f, 1f,
+                    infiniteRepeatable(tween(1400), RepeatMode.Reverse, StartOffset(i * 50)),
+                    label = "b$i",
+                )
+                val sy = if (active) h else 0.5f
+                Box(
+                    Modifier
+                        .weight(1f)
+                        .fillMaxSize()
+                        .graphicsLayer { scaleY = sy }
+                        .clip(RoundedCornerShape(2.dp))
+                        .background(if (active) cs.meshGreen else cs.meshBorder),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Hero(active: Boolean, style: HeroStyle) {
+    when (style) {
+        HeroStyle.Bar -> HeroBar(active)
+        else -> HeroRings(active)
+    }
+}
+
+data class MeshHomeActions(
+    val onStart: () -> Unit,
+    val onEnd: () -> Unit,
+    val onOpenSettings: () -> Unit,
+    val onOpenLearn: () -> Unit,
+    val onOpenExitNodes: () -> Unit,
+    val onOpenAdb: () -> Unit,
+)
+
+@Composable
+fun MeshHomeScreen(
+    connected: Boolean,
+    actions: MeshHomeActions,
+    heroStyle: HeroStyle = HeroStyle.Rings,
+    analyst: Analyst = MeshSample.analyst,
+    exitNodeName: String? = null,
+    adbReady: Boolean = false,
+) {
+    val cs = MaterialTheme.colorScheme
+
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(cs.meshBg)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        Row(
+            Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 16.dp, bottom = 4.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Image(
+                    painter = painterResource(R.drawable.mesh_wordmark),
+                    contentDescription = "MESH",
+                    colorFilter = ColorFilter.tint(cs.meshText),
+                    modifier = Modifier.height(20.dp),
+                )
+                Spacer(Modifier.width(8.dp))
+                Text("v${AppVersion.Short()}", color = cs.meshMuted, fontFamily = MeshMono, fontSize = 9.5.sp, modifier = Modifier.padding(top = 4.dp))
+            }
+            Box(Modifier.size(34.dp).clip(CircleShape).clickable(onClick = actions.onOpenSettings), contentAlignment = Alignment.Center) {
+                MeshIcon("gear", size = 21.dp, color = cs.meshText2)
+            }
+        }
+
+        Column(
+            Modifier.fillMaxWidth().padding(horizontal = 24.dp, vertical = 6.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Hero(connected, heroStyle)
+            Spacer(Modifier.height(18.dp))
+            Row(
+                Modifier
+                    .meshCard(
+                        RoundedCornerShape(999.dp),
+                        if (connected) cs.meshGreenDim else cs.meshCard,
+                        if (connected) cs.meshGreen.copy(alpha = 0.4f) else cs.meshBorder,
+                    )
+                    .padding(horizontal = 14.dp, vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                StatusDot(if (connected) cs.meshGreen else cs.meshMuted, size = 8.dp, pulse = connected)
+                Text(
+                    if (connected) stringResource(R.string.mesh_status_connected_enc) else stringResource(R.string.mesh_status_not_connected),
+                    color = if (connected) cs.meshGreen else cs.meshText2,
+                    fontSize = 12.5.sp, fontWeight = FontWeight.Bold,
+                )
+            }
+            Spacer(Modifier.height(16.dp))
+            Text(
+                if (connected) stringResource(R.string.mesh_home_conn_title) else stringResource(R.string.mesh_home_disc_title),
+                color = cs.meshText, fontSize = 22.sp, fontWeight = FontWeight.SemiBold, textAlign = TextAlign.Center, letterSpacing = (-0.3).sp,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                if (connected) stringResource(R.string.mesh_home_conn_body) else stringResource(R.string.mesh_home_disc_body),
+                color = cs.meshText2, fontSize = 13.5.sp, lineHeight = 20.sp, textAlign = TextAlign.Center,
+                modifier = Modifier.widthIn(max = 300.dp),
+            )
+        }
+
+        Column(
+            Modifier.fillMaxWidth().padding(start = 18.dp, end = 18.dp, top = 20.dp, bottom = 28.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            if (!connected) {
+                MeshButton(stringResource(R.string.mesh_start_cta), actions.onStart, full = true, height = 56.dp, icon = "shield")
+                Row(horizontalArrangement = Arrangement.spacedBy(9.dp)) {
+                    InfoTile(Modifier.weight(1f), "lock", stringResource(R.string.mesh_tile_encrypted_title), stringResource(R.string.mesh_tile_encrypted_sub))
+                    InfoTile(Modifier.weight(1f), "eyeOff", stringResource(R.string.mesh_tile_notrack_title), stringResource(R.string.mesh_tile_notrack_sub))
+                    InfoTile(Modifier.weight(1f), "power", stringResource(R.string.mesh_tile_control_title), stringResource(R.string.mesh_tile_control_sub))
+                }
+                AdbCard(adbReady, actions.onOpenAdb)
+                MeshCard(onClick = actions.onOpenLearn) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Box(Modifier.size(34.dp).clip(RoundedCornerShape(10.dp)).background(cs.accentDim(0.14f)), contentAlignment = Alignment.Center) {
+                            MeshIcon("info", size = 18.dp, color = cs.accent)
+                        }
+                        Column(Modifier.weight(1f)) {
+                            Text(stringResource(R.string.mesh_learn_card_title), color = cs.meshText, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+                            Text(stringResource(R.string.mesh_learn_card_sub), color = cs.meshText2, fontSize = 12.sp)
+                        }
+                        MeshIcon("chevR", size = 18.dp, color = cs.meshMuted)
+                    }
+                }
+            } else {
+                AnalystCard(analyst)
+                ExitNodeCard(exitNodeName, actions.onOpenExitNodes)
+                MeshButton(stringResource(R.string.mesh_end_cta), actions.onEnd, full = true, height = 56.dp, icon = "power", variant = MeshButtonVariant.Danger)
+            }
+        }
+    }
+}
+
+/** Analyst identity card — name and mesh IP. */
+@Composable
+private fun AnalystCard(a: Analyst) {
+    val cs = MaterialTheme.colorScheme
+    val shape = RoundedCornerShape(com.barghest.mesh.ui.theme.MeshRadii.card)
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .meshCard(shape, cs.meshCard, cs.meshBorder)
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(Modifier.size(46.dp).clip(RoundedCornerShape(12.dp)).background(cs.accentDim(0.16f)), contentAlignment = Alignment.Center) {
+            MeshIcon("user", size = 24.dp, color = cs.accent)
+        }
+        Column(Modifier.weight(1f)) {
+            Eyebrow(stringResource(R.string.mesh_analyst_label), color = cs.accent)
+            Spacer(Modifier.height(4.dp))
+            Text(a.name, color = cs.meshText, fontSize = 15.5.sp, fontWeight = FontWeight.SemiBold)
+            MonoText(a.ip, color = cs.meshText2, fontSize = 12.sp)
+        }
+    }
+}
+
+/** Exit-node selector — taps through to the existing picker. */
+@Composable
+private fun ExitNodeCard(name: String?, onOpen: () -> Unit) {
+    val cs = MaterialTheme.colorScheme
+    val shape = RoundedCornerShape(com.barghest.mesh.ui.theme.MeshRadii.card)
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .meshCard(shape, cs.meshCard, cs.meshBorder)
+            .clickable(onClick = onOpen)
+            .padding(14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(Modifier.size(34.dp).clip(RoundedCornerShape(10.dp)).background(cs.accentDim(0.14f)), contentAlignment = Alignment.Center) {
+            MeshIcon("globe", size = 18.dp, color = cs.accent)
+        }
+        Column(Modifier.weight(1f)) {
+            Text(stringResource(R.string.mesh_exit_node), color = cs.meshText, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+            Text(name ?: stringResource(R.string.mesh_exit_node_none), color = cs.meshText2, fontSize = 12.sp)
+        }
+        MeshIcon("chevR", size = 18.dp, color = cs.meshMuted)
+    }
+}
+
+/** Wireless-debugging (ADB) prerequisite card with readiness state. */
+@Composable
+private fun AdbCard(ready: Boolean, onOpen: () -> Unit) {
+    val cs = MaterialTheme.colorScheme
+    val shape = RoundedCornerShape(com.barghest.mesh.ui.theme.MeshRadii.card)
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .meshCard(shape, cs.meshCard, if (ready) cs.meshGreen.copy(alpha = 0.4f) else cs.meshBorder)
+            .clickable(onClick = onOpen)
+            .padding(14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Box(
+            Modifier.size(34.dp).clip(RoundedCornerShape(10.dp)).background(if (ready) cs.meshGreenDim else cs.meshAmberDim),
+            contentAlignment = Alignment.Center,
+        ) { MeshIcon(if (ready) "check" else "wifi", size = 18.dp, color = if (ready) cs.meshGreen else cs.meshAmber) }
+        Column(Modifier.weight(1f)) {
+            Text(if (ready) stringResource(R.string.mesh_adb_on_title) else stringResource(R.string.mesh_adb_off_title), color = cs.meshText, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+            Text(if (ready) stringResource(R.string.mesh_adb_on_sub) else stringResource(R.string.mesh_adb_off_sub), color = cs.meshText2, fontSize = 12.sp)
+        }
+        MeshIcon("chevR", size = 18.dp, color = cs.meshMuted)
+    }
+}
+
+@Composable
+private fun InfoTile(modifier: Modifier, icon: String, title: String, sub: String) {
+    val cs = MaterialTheme.colorScheme
+    Column(
+        modifier
+            .meshCard(RoundedCornerShape(16.dp), cs.meshCard, cs.meshBorder)
+            .padding(horizontal = 8.dp, vertical = 12.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        MeshIcon(icon, size = 18.dp, color = cs.meshText2)
+        Spacer(Modifier.height(7.dp))
+        Text(title, color = cs.meshText, fontSize = 12.5.sp, fontWeight = FontWeight.SemiBold)
+        Text(sub, color = cs.meshMuted, fontSize = 11.sp, textAlign = TextAlign.Center)
+    }
+}
+

--- a/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshIcon.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshIcon.kt
@@ -1,0 +1,123 @@
+// Copyright (c) BARGHEST
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.barghest.mesh.ui.view.mesh
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.scale
+import androidx.compose.ui.graphics.vector.PathParser
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/** Bespoke 24×24 stroke-icon set drawn via PathParser; [stroke] is in 24-unit terms. */
+@Composable
+fun MeshIcon(
+    name: String,
+    size: Dp = 22.dp,
+    color: Color = Color.Unspecified,
+    stroke: Float = 1.7f,
+    modifier: Modifier = Modifier,
+) {
+    val tint = color.takeIf { it != Color.Unspecified } ?: Color(0xFFF4F2ED)
+    Canvas(modifier = modifier.size(size)) {
+        val unit = this.size.minDimension / 24f
+        scale(unit, unit, pivot = Offset.Zero) {
+            drawMeshIcon(name, tint, stroke)
+        }
+    }
+}
+
+// Parse each path once and reuse it; re-parsing on every draw was a source of jank.
+private val pathCache = java.util.concurrent.ConcurrentHashMap<String, Path>()
+
+private fun pp(d: String): Path = pathCache.getOrPut(d) { PathParser().parsePathString(d).toPath() }
+
+/** Draws one named glyph in 24-unit coordinates. */
+private fun DrawScope.drawMeshIcon(name: String, c: Color, w: Float) {
+    val s = Stroke(width = w, cap = StrokeCap.Round, join = StrokeJoin.Round)
+
+    fun path(d: String) = drawPath(pp(d), c, style = s)
+    fun line(x1: Float, y1: Float, x2: Float, y2: Float) =
+        drawLine(c, Offset(x1, y1), Offset(x2, y2), strokeWidth = w, cap = StrokeCap.Round)
+    fun circle(cx: Float, cy: Float, r: Float, fill: Boolean = false) =
+        if (fill) drawCircle(c, r, Offset(cx, cy))
+        else drawCircle(c, r, Offset(cx, cy), style = s)
+    fun rrect(x: Float, y: Float, ww: Float, hh: Float, rx: Float) =
+        drawRoundRect(c, Offset(x, y), Size(ww, hh), CornerRadius(rx, rx), style = s)
+
+    when (name) {
+        "shield" -> path("M12 3l7 3v5c0 4.4-3 7.7-7 9-4-1.3-7-4.6-7-9V6l7-3z")
+        "lock" -> { rrect(5f, 11f, 14f, 9f, 2f); path("M8 11V8a4 4 0 0 1 8 0v3") }
+        "check" -> path("M5 12.5l4.5 4.5L19 7")
+        "x" -> { line(6f, 6f, 18f, 18f); line(18f, 6f, 6f, 18f) }
+        "chevL" -> path("M15 5l-7 7 7 7")
+        "chevR" -> path("M9 5l7 7-7 7")
+        "chevD" -> path("M5 9l7 7 7-7")
+        "gear" -> {
+            // Filled cog — a bare circle with radial ticks reads as a brightness toggle.
+            val g = pp(
+                "M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61" +
+                    "l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54" +
+                    "c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94" +
+                    "l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94" +
+                    "s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96" +
+                    "c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54" +
+                    "c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61" +
+                    "l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z",
+            )
+            g.fillType = PathFillType.EvenOdd
+            drawPath(g, c)
+        }
+        "phone" -> { rrect(6.5f, 2.5f, 11f, 19f, 2.5f); path("M10.5 18.5h3") }
+        "laptop" -> { rrect(4f, 5f, 16f, 11f, 1.5f); path("M2.5 19.5h19") }
+        "grid" -> {
+            rrect(4f, 4f, 6.5f, 6.5f, 1.2f); rrect(13.5f, 4f, 6.5f, 6.5f, 1.2f)
+            rrect(4f, 13.5f, 6.5f, 6.5f, 1.2f); rrect(13.5f, 13.5f, 6.5f, 6.5f, 1.2f)
+        }
+        "file" -> { path("M7 3h7l4 4v14H7z"); path("M14 3v4h4") }
+        "scan" -> {
+            path("M4 8V5.5A1.5 1.5 0 0 1 5.5 4H8M16 4h2.5A1.5 1.5 0 0 1 20 5.5V8M20 16v2.5a1.5 1.5 0 0 1-1.5 1.5H16M8 20H5.5A1.5 1.5 0 0 1 4 18.5V16")
+            path("M4 12h16")
+        }
+        "link" -> {
+            path("M9 15l6-6"); path("M11 7l1-1a4 4 0 0 1 6 6l-1 1"); path("M13 17l-1 1a4 4 0 0 1-6-6l1-1")
+        }
+        "activity", "pulse" -> path("M3 12h4l2.5 7 5-14L17 12h4")
+        "qr" -> {
+            rrect(4f, 4f, 6f, 6f, 1f); rrect(14f, 4f, 6f, 6f, 1f); rrect(4f, 14f, 6f, 6f, 1f)
+            path("M14 14h3v3M20 14v6M14 20h3")
+        }
+        "key" -> { circle(8f, 8f, 4f); path("M11 11l8 8M16 16l2-2M18 18l2-2") }
+        "eye" -> { path("M2.5 12S6 5.5 12 5.5 21.5 12 21.5 12 18 18.5 12 18.5 2.5 12 2.5 12z"); circle(12f, 12f, 3f) }
+        "eyeOff" -> {
+            path("M4 4l16 16")
+            path("M9.5 9.6A3 3 0 0 0 12 15a3 3 0 0 0 2.4-1.2")
+            path("M6.5 6.7C4 8.3 2.5 12 2.5 12s3.5 6.5 9.5 6.5c1.6 0 3-.4 4.2-1M9.8 5.8A8 8 0 0 1 12 5.5c6 0 9.5 6.5 9.5 6.5a16 16 0 0 1-2 2.7")
+        }
+        "alert" -> { path("M12 3l9.5 17h-19L12 3z"); path("M12 10v4.5M12 17.6v.01") }
+        "power" -> { path("M12 3v9"); path("M6.5 7a8 8 0 1 0 11 0") }
+        "wifi" -> { path("M2.5 9.5a14 14 0 0 1 19 0M5.5 13a9 9 0 0 1 13 0M8.5 16.5a4.5 4.5 0 0 1 7 0"); path("M12 20.5v.01") }
+        "user" -> { circle(12f, 8f, 4f); path("M4.5 20a7.5 7.5 0 0 1 15 0") }
+        "relay" -> {
+            circle(12f, 12f, 2.5f); circle(4f, 6f, 2f); circle(20f, 6f, 2f); circle(12f, 20f, 2f)
+            path("M10 11l-4.5-3.5M14 11l4.5-3.5M12 14.5v3.5")
+        }
+        "info" -> { circle(12f, 12f, 9f); path("M12 11v5M12 8v.01") }
+        "bell" -> { path("M6 9a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6"); path("M10 19a2 2 0 0 0 4 0") }
+        "globe" -> { circle(12f, 12f, 9f); path("M3 12h18M12 3c2.5 2.5 2.5 15 0 18M12 3c-2.5 2.5-2.5 15 0 18") }
+        else -> Unit
+    }
+}

--- a/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshMockData.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshMockData.kt
@@ -1,0 +1,22 @@
+// Copyright (c) BARGHEST
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.barghest.mesh.ui.view.mesh
+
+/** Sample analyst + guided copy; live name/IP come from the netmap peer in production. */
+
+data class Analyst(
+    val name: String,
+    val org: String,
+    val ip: String,
+    val verified: Boolean,
+)
+
+object MeshSample {
+    val analyst = Analyst(
+        name = "Your analyst",
+        org = "",
+        ip = "—",
+        verified = false,
+    )
+}

--- a/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshModels.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshModels.kt
@@ -1,0 +1,23 @@
+// Copyright (c) BARGHEST
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.barghest.mesh.ui.view.mesh
+
+/** Identity of the analyst on the other end of a session; live name/IP come from the netmap peer. */
+data class Analyst(
+    val name: String,
+    val org: String,
+    val ip: String,
+    val verified: Boolean,
+)
+
+/** Empty-state defaults shown until a real peer identity is available. */
+object MeshDefaults {
+    // No display copy here — a blank name renders the localized placeholder at the call site.
+    val analyst = Analyst(
+        name = "",
+        org = "",
+        ip = "—",
+        verified = false,
+    )
+}

--- a/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshOnboarding.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshOnboarding.kt
@@ -1,0 +1,273 @@
+// Copyright (c) BARGHEST
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.barghest.mesh.ui.view.mesh
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.barghest.mesh.R
+import com.barghest.mesh.ui.view.onboarding.QuizDialog
+import com.barghest.mesh.ui.view.onboarding.WarningDialog
+import com.barghest.mesh.ui.theme.accent
+import com.barghest.mesh.ui.theme.accentDim
+import com.barghest.mesh.ui.theme.meshBg
+import com.barghest.mesh.ui.theme.meshBorderHi
+import com.barghest.mesh.ui.theme.meshGreen
+import com.barghest.mesh.ui.theme.meshMuted
+import com.barghest.mesh.ui.theme.meshText
+import com.barghest.mesh.ui.theme.meshText2
+
+@Composable
+private fun OnbBullet(text: String) {
+    val cs = MaterialTheme.colorScheme
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 9.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        Box(
+            Modifier
+                .padding(top = 1.dp)
+                .size(22.dp)
+                .background(cs.accentDim(0.16f), RoundedCornerShape(7.dp)),
+            contentAlignment = Alignment.Center,
+        ) { MeshIcon("check", size = 14.dp, color = cs.accent, stroke = 2.2f) }
+        Text(text, color = cs.meshText2, fontSize = 14.5.sp, lineHeight = 21.sp)
+    }
+}
+
+@Composable
+fun MeshOnboarding(onDone: () -> Unit) {
+    val cs = MaterialTheme.colorScheme
+    var page by remember { mutableIntStateOf(0) }
+    val pages = 3
+
+    // Comprehension pop-quizzes gating the "how it works" and consent pages, ported from
+    // the legacy onboarding (true/false → feedback; a wrong answer shows a warning, then
+    // proceeds either way).
+    var activeQuiz by remember { mutableIntStateOf(0) }
+    var showQuiz by remember { mutableStateOf(false) }
+    var showWarning by remember { mutableStateOf(false) }
+    var warningMessage by remember { mutableStateOf("") }
+
+    val quizConsent = stringResource(R.string.mesh_quiz_consent)
+    val quizAdb = stringResource(R.string.mesh_quiz_adb)
+    val warnConsent = stringResource(R.string.mesh_warn_consent)
+    val warnAdb = stringResource(R.string.mesh_warn_adb)
+
+    fun proceedAfterQuiz() {
+        if (activeQuiz == 2) onDone() else page = 2
+    }
+
+    if (showQuiz) {
+        QuizDialog(
+            title = stringResource(R.string.mesh_quiz_title),
+            question = if (activeQuiz == 1) quizConsent else quizAdb,
+            onAnswer = { answeredTrue ->
+                showQuiz = false
+                if (answeredTrue) {
+                    proceedAfterQuiz()
+                } else {
+                    warningMessage = if (activeQuiz == 1) warnConsent else warnAdb
+                    showWarning = true
+                }
+            },
+        )
+    }
+    if (showWarning) {
+        WarningDialog(message = warningMessage, onDismiss = { showWarning = false; proceedAfterQuiz() })
+    }
+
+    Column(
+        Modifier.fillMaxSize().background(cs.meshBg).statusBarsPadding().navigationBarsPadding(),
+    ) {
+        Spacer(Modifier.height(14.dp))
+        AnimatedContent(
+            targetState = page,
+            transitionSpec = { fadeIn(tween(350)) togetherWith fadeOut(tween(150)) },
+            modifier = Modifier.weight(1f),
+            label = "onbPage",
+        ) { p ->
+            when (p) {
+                0 -> Welcome()
+                1 -> HowItWorks()
+                else -> Consent()
+            }
+        }
+
+        Column(Modifier.padding(start = 26.dp, end = 26.dp, top = 16.dp, bottom = 26.dp)) {
+            Row(
+                Modifier.fillMaxWidth().padding(bottom = 18.dp),
+                horizontalArrangement = Arrangement.spacedBy(7.dp, Alignment.CenterHorizontally),
+            ) {
+                repeat(pages) { i ->
+                    val w by animateDpAsState(if (i == page) 24.dp else 5.dp, label = "ind")
+                    Box(
+                        Modifier
+                            .height(5.dp)
+                            .width(w)
+                            .background(
+                                if (i == page) cs.accent else cs.meshBorderHi,
+                                RoundedCornerShape(3.dp),
+                            ),
+                    )
+                }
+            }
+            MeshButton(
+                text = when (page) {
+                    0 -> stringResource(R.string.mesh_onb_get_started)
+                    pages - 1 -> stringResource(R.string.mesh_onb_understand)
+                    else -> stringResource(R.string.mesh_onb_continue)
+                },
+                onClick = {
+                    when (page) {
+                        0 -> page = 1
+                        1 -> { activeQuiz = 1; showQuiz = true }
+                        else -> { activeQuiz = 2; showQuiz = true }
+                    }
+                },
+                full = true,
+                height = 56.dp,
+                icon = if (page == pages - 1) "check" else "chevR",
+            )
+            if (page > 0) {
+                Text(
+                    stringResource(R.string.mesh_back),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp)
+                        .clickable { page-- },
+                    color = cs.meshMuted,
+                    fontSize = 12.5.sp,
+                    fontWeight = FontWeight.Medium,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Welcome() {
+    val cs = MaterialTheme.colorScheme
+    Column(
+        Modifier.fillMaxSize().padding(horizontal = 30.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Image(
+            painter = painterResource(R.drawable.mesh_wordmark),
+            contentDescription = "MESH",
+            colorFilter = ColorFilter.tint(cs.meshText),
+            modifier = Modifier.fillMaxWidth(0.82f),
+        )
+        Spacer(Modifier.height(20.dp))
+        Eyebrow(stringResource(R.string.mesh_onb_welcome_eyebrow))
+        Spacer(Modifier.height(22.dp))
+        Text(
+            stringResource(R.string.mesh_onb_welcome_body),
+            color = cs.meshText2, fontSize = 15.sp, lineHeight = 24.sp, textAlign = TextAlign.Center,
+            modifier = Modifier.widthIn(max = 320.dp),
+        )
+        Spacer(Modifier.height(22.dp))
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(7.dp)) {
+            StatusDot(cs.meshGreen, size = 7.dp)
+            Text(stringResource(R.string.mesh_onb_welcome_tag), color = cs.meshMuted, fontSize = 11.5.sp, fontWeight = FontWeight.Medium)
+        }
+    }
+}
+
+@Composable
+private fun HowItWorks() {
+    val cs = MaterialTheme.colorScheme
+    Column(Modifier.fillMaxSize().padding(start = 26.dp, end = 26.dp, top = 12.dp)) {
+        Eyebrow(stringResource(R.string.mesh_onb_how_eyebrow), color = cs.accent)
+        Spacer(Modifier.height(10.dp))
+        Text(stringResource(R.string.mesh_onb_how_title), color = cs.meshText, fontSize = 25.sp, fontWeight = FontWeight.SemiBold, lineHeight = 30.sp, letterSpacing = (-0.4).sp)
+        Spacer(Modifier.height(8.dp))
+        Text(
+            stringResource(R.string.mesh_onb_how_body),
+            color = cs.meshText2, fontSize = 14.5.sp, lineHeight = 22.sp,
+        )
+        Spacer(Modifier.height(14.dp))
+        OnbBullet(stringResource(R.string.mesh_onb_how_b1))
+        OnbBullet(stringResource(R.string.mesh_onb_how_b2))
+        OnbBullet(stringResource(R.string.mesh_onb_how_b3))
+        OnbBullet(stringResource(R.string.mesh_onb_how_b4))
+    }
+}
+
+@Composable
+private fun Consent() {
+    val cs = MaterialTheme.colorScheme
+    Column(Modifier.fillMaxSize().padding(start = 26.dp, end = 26.dp, top = 12.dp)) {
+        Eyebrow(stringResource(R.string.mesh_onb_consent_eyebrow), color = cs.accent)
+        Spacer(Modifier.height(10.dp))
+        Text(stringResource(R.string.mesh_onb_consent_title), color = cs.meshText, fontSize = 25.sp, fontWeight = FontWeight.SemiBold, lineHeight = 30.sp, letterSpacing = (-0.4).sp)
+        Spacer(Modifier.height(8.dp))
+        Text(
+            stringResource(R.string.mesh_onb_consent_body),
+            color = cs.meshText2, fontSize = 14.5.sp, lineHeight = 22.sp,
+        )
+        Spacer(Modifier.height(14.dp))
+        OnbBullet(stringResource(R.string.mesh_onb_consent_b1))
+        OnbBullet(stringResource(R.string.mesh_onb_consent_b2))
+        OnbBullet(stringResource(R.string.mesh_onb_consent_b3))
+        Spacer(Modifier.height(16.dp))
+        Row(
+            Modifier
+                .fillMaxWidth()
+                .background(cs.accentDim(0.10f), RoundedCornerShape(12.dp))
+                .border(1.dp, cs.accentDim(0.30f), RoundedCornerShape(12.dp))
+                .padding(14.dp),
+            horizontalArrangement = Arrangement.spacedBy(11.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            MeshIcon("lock", size = 18.dp, color = cs.accent, modifier = Modifier.padding(top = 1.dp))
+            Text(
+                stringResource(R.string.mesh_onb_consent_note),
+                color = cs.meshText2, fontSize = 13.sp, lineHeight = 20.sp,
+            )
+        }
+    }
+}

--- a/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshSettings.kt
+++ b/android-client/android/src/main/java/com/barghest/mesh/ui/view/mesh/MeshSettings.kt
@@ -1,0 +1,241 @@
+// Copyright (c) BARGHEST
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package com.barghest.mesh.ui.view.mesh
+
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.barghest.mesh.R
+import com.barghest.mesh.ui.Links
+import com.barghest.mesh.ui.theme.MeshRadii
+import com.barghest.mesh.ui.util.AppVersion
+import com.barghest.mesh.ui.theme.accent
+import com.barghest.mesh.ui.theme.accentDim
+import com.barghest.mesh.ui.theme.meshBg
+import com.barghest.mesh.ui.theme.meshBgRaised
+import com.barghest.mesh.ui.theme.meshBorder
+import com.barghest.mesh.ui.theme.meshBorderHi
+import com.barghest.mesh.ui.theme.meshCard
+import com.barghest.mesh.ui.theme.meshGreen
+import com.barghest.mesh.ui.theme.meshGreenDim
+import com.barghest.mesh.ui.theme.meshMuted
+import com.barghest.mesh.ui.theme.meshRed
+import com.barghest.mesh.ui.theme.meshRedDim
+import com.barghest.mesh.ui.theme.meshText
+import com.barghest.mesh.ui.theme.meshText2
+
+@Composable
+private fun SettingRow(
+    icon: String,
+    title: String,
+    sub: String? = null,
+    danger: Boolean = false,
+    onClick: (() -> Unit)? = null,
+    control: @Composable () -> Unit,
+) {
+    val cs = MaterialTheme.colorScheme
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(horizontal = 14.dp, vertical = 13.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(13.dp),
+    ) {
+        Box(Modifier.size(34.dp).background(if (danger) cs.meshRedDim else cs.accentDim(0.13f), RoundedCornerShape(10.dp)), contentAlignment = Alignment.Center) {
+            MeshIcon(icon, size = 18.dp, color = if (danger) cs.meshRed else cs.accent)
+        }
+        Column(Modifier.weight(1f)) {
+            Text(title, color = if (danger) cs.meshRed else cs.meshText, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+            if (sub != null) Text(sub, color = cs.meshText2, fontSize = 12.sp)
+        }
+        control()
+    }
+}
+
+@Composable
+private fun Group(label: String, content: @Composable () -> Unit) {
+    val cs = MaterialTheme.colorScheme
+    Column(Modifier.padding(bottom = 18.dp)) {
+        Eyebrow(label, modifier = Modifier.padding(start = 4.dp, bottom = 8.dp))
+        Column(Modifier.fillMaxWidth().background(cs.meshCard, RoundedCornerShape(MeshRadii.card)).border(1.dp, cs.meshBorder, RoundedCornerShape(MeshRadii.card))) {
+            content()
+        }
+    }
+}
+
+@Composable
+private fun Divider() {
+    Box(Modifier.fillMaxWidth().height(1.dp).background(MaterialTheme.colorScheme.meshBorder))
+}
+
+/** Live Settings wiring; null runs the self-contained demo. */
+data class MeshSettingsLive(
+    val controlUrl: String?,
+    val onOpenControlServer: () -> Unit,
+    val onOpenExitNodes: () -> Unit,
+    val onOpenDns: () -> Unit,
+    val onOpenSplitTunnel: () -> Unit,
+    val onOpenObfuscation: () -> Unit,
+    val onForgetEnrollment: () -> Unit,
+)
+
+@Composable
+fun MeshSettingsScreen(onBack: () -> Unit, live: MeshSettingsLive? = null) {
+    val cs = MaterialTheme.colorScheme
+    val uriHandler = LocalUriHandler.current
+
+    Column(Modifier.fillMaxSize().background(cs.meshBg)) {
+        MeshTopBar(stringResource(R.string.mesh_topbar_settings), onBack = onBack)
+        Column(Modifier.weight(1f).verticalScroll(rememberScrollState()).padding(horizontal = 18.dp, vertical = 16.dp)) {
+            Group(stringResource(R.string.mesh_set_group_connection)) {
+                SettingRow("globe", stringResource(R.string.mesh_set_control_server), live?.controlUrl?.takeIf { it.isNotEmpty() } ?: stringResource(R.string.mesh_set_not_configured), onClick = live?.onOpenControlServer ?: {}) {
+                    MeshIcon("chevR", size = 17.dp, color = cs.meshMuted)
+                }
+                Divider()
+                SettingRow("globe", stringResource(R.string.mesh_set_exit_node), stringResource(R.string.mesh_set_exit_node_sub), onClick = live?.onOpenExitNodes ?: {}) {
+                    MeshIcon("chevR", size = 17.dp, color = cs.meshMuted)
+                }
+            }
+            Group(stringResource(R.string.mesh_set_group_network)) {
+                SettingRow("globe", stringResource(R.string.mesh_set_magic_dns), stringResource(R.string.mesh_set_magic_dns_sub), onClick = live?.onOpenDns ?: {}) {
+                    MeshIcon("chevR", size = 17.dp, color = cs.meshMuted)
+                }
+                Divider()
+                SettingRow("grid", stringResource(R.string.mesh_set_split), stringResource(R.string.mesh_set_split_sub), onClick = live?.onOpenSplitTunnel ?: {}) {
+                    MeshIcon("chevR", size = 17.dp, color = cs.meshMuted)
+                }
+            }
+            Group(stringResource(R.string.mesh_set_group_privacy)) {
+                SettingRow("eyeOff", stringResource(R.string.mesh_set_obfuscation), stringResource(R.string.mesh_set_obfuscation_sub), onClick = live?.onOpenObfuscation ?: {}) {
+                    MeshIcon("chevR", size = 17.dp, color = cs.meshMuted)
+                }
+            }
+            Group(stringResource(R.string.mesh_set_group_about)) {
+                SettingRow("info", stringResource(R.string.mesh_set_version, AppVersion.Short()), stringResource(R.string.mesh_set_source), onClick = { uriHandler.openUri(Links.SOURCE_REPO_URL) }) {
+                    MeshIcon("chevR", size = 17.dp, color = cs.meshMuted)
+                }
+                Divider()
+                SettingRow("file", stringResource(R.string.mesh_set_license), stringResource(R.string.mesh_set_license_sub), onClick = { uriHandler.openUri(Links.LICENSE_URL) }) {
+                    MeshIcon("chevR", size = 17.dp, color = cs.meshMuted)
+                }
+            }
+            Group(stringResource(R.string.mesh_set_group_danger)) {
+                SettingRow("x", stringResource(R.string.mesh_set_forget), stringResource(R.string.mesh_set_forget_sub), danger = true, onClick = live?.onForgetEnrollment ?: {}) {
+                    MeshIcon("chevR", size = 17.dp, color = cs.meshRed)
+                }
+            }
+            Text(stringResource(R.string.mesh_set_footer), color = cs.meshMuted, fontSize = 11.5.sp, fontWeight = FontWeight.Medium, modifier = Modifier.fillMaxWidth().padding(top = 8.dp), textAlign = TextAlign.Center)
+        }
+    }
+}
+
+private data class LearnStep(val icon: String, val title: String, val body: String)
+
+@Composable
+fun MeshLearnScreen(onBack: () -> Unit, onStart: () -> Unit) {
+    val cs = MaterialTheme.colorScheme
+    val steps = listOf(
+        LearnStep("qr", stringResource(R.string.mesh_learn_s1_title), stringResource(R.string.mesh_learn_s1_body)),
+        LearnStep("lock", stringResource(R.string.mesh_learn_s2_title), stringResource(R.string.mesh_learn_s2_body)),
+        LearnStep("eye", stringResource(R.string.mesh_learn_s3_title), stringResource(R.string.mesh_learn_s3_body)),
+        LearnStep("power", stringResource(R.string.mesh_learn_s4_title), stringResource(R.string.mesh_learn_s4_body)),
+    )
+    Column(Modifier.fillMaxSize().background(cs.meshBg)) {
+        MeshTopBar(stringResource(R.string.mesh_learn_topbar), onBack = onBack)
+        Column(Modifier.weight(1f).verticalScroll(rememberScrollState()).padding(horizontal = 20.dp)) {
+            Spacer(Modifier.height(18.dp))
+            Text(
+                stringResource(R.string.mesh_learn_intro),
+                color = cs.meshText2, fontSize = 14.5.sp, lineHeight = 22.sp,
+            )
+            Spacer(Modifier.height(22.dp))
+            steps.forEachIndexed { i, s ->
+                Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(14.dp)) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Box(
+                            Modifier.size(42.dp).background(cs.accentDim(0.14f), RoundedCornerShape(13.dp)).border(1.dp, cs.accentDim(0.3f), RoundedCornerShape(13.dp)),
+                            contentAlignment = Alignment.Center,
+                        ) { MeshIcon(s.icon, size = 20.dp, color = cs.accent) }
+                        if (i < steps.lastIndex) Box(Modifier.padding(vertical = 6.dp).width(1.5.dp).height(22.dp).background(cs.meshBorder))
+                    }
+                    Column(Modifier.padding(bottom = if (i < steps.lastIndex) 0.dp else 22.dp)) {
+                        Text(s.title, color = cs.meshText, fontSize = 15.5.sp, fontWeight = FontWeight.SemiBold)
+                        Spacer(Modifier.height(4.dp))
+                        Text(s.body, color = cs.meshText2, fontSize = 13.sp, lineHeight = 19.sp)
+                    }
+                }
+            }
+        }
+        Column(Modifier.fillMaxWidth().background(cs.meshBg)) {
+            Divider()
+            Box(Modifier.padding(horizontal = 20.dp, vertical = 14.dp)) {
+                MeshButton(stringResource(R.string.mesh_start_cta), onStart, full = true, height = 56.dp, icon = "shield")
+            }
+        }
+    }
+}
+
+@Composable
+fun MeshConfirmSheet(onCancel: () -> Unit, onConfirm: () -> Unit) {
+    val cs = MaterialTheme.colorScheme
+    Box(Modifier.fillMaxSize()) {
+        Box(Modifier.fillMaxSize().background(Color(0x99000000)).clickable(onClick = onCancel))
+        Column(
+            Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .background(cs.meshBgRaised, RoundedCornerShape(topStart = 22.dp, topEnd = 22.dp))
+                .border(1.dp, cs.meshBorder, RoundedCornerShape(topStart = 22.dp, topEnd = 22.dp))
+                .padding(start = 20.dp, end = 20.dp, top = 10.dp, bottom = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Box(Modifier.padding(bottom = 18.dp).width(38.dp).height(4.dp).background(cs.meshBorderHi, RoundedCornerShape(2.dp)))
+            Box(Modifier.size(54.dp).background(cs.meshRedDim, RoundedCornerShape(16.dp)), contentAlignment = Alignment.Center) {
+                MeshIcon("power", size = 26.dp, color = cs.meshRed)
+            }
+            Spacer(Modifier.height(16.dp))
+            Text(stringResource(R.string.mesh_end_confirm_title), color = cs.meshText, fontSize = 19.sp, fontWeight = FontWeight.Bold, textAlign = TextAlign.Center)
+            Spacer(Modifier.height(8.dp))
+            Text(stringResource(R.string.mesh_end_confirm_body), color = cs.meshText2, fontSize = 13.5.sp, lineHeight = 20.sp, textAlign = TextAlign.Center)
+            Spacer(Modifier.height(22.dp))
+            MeshButton(stringResource(R.string.mesh_end_cta), onConfirm, full = true, height = 56.dp, icon = "power", variant = MeshButtonVariant.Danger)
+            Spacer(Modifier.height(10.dp))
+            MeshButton(stringResource(R.string.mesh_keep_session), onCancel, full = true, height = 52.dp, variant = MeshButtonVariant.Ghost)
+        }
+    }
+}

--- a/android-client/android/src/main/res/values/strings.xml
+++ b/android-client/android/src/main/res/values/strings.xml
@@ -443,4 +443,123 @@
     <string name="reset_failed">Unable to reset MESH at this time. Please try again.</string>
     <string name="reset_failed_title">Reset failed</string>
 
+    <!-- ============ Redesigned client (ui/view/mesh) ============ -->
+    <!-- Onboarding -->
+    <string name="mesh_onb_get_started">Get started</string>
+    <string name="mesh_onb_continue">Continue</string>
+    <string name="mesh_onb_understand">I understand</string>
+    <string name="mesh_back">back</string>
+    <string name="mesh_quiz_title">Pop quiz!</string>
+    <string name="mesh_quiz_consent">Consensual forensics may involve granting access to sensitive data on your device.</string>
+    <string name="mesh_quiz_adb">Leaving ADB enabled when not in use can increase security risks if your device is accessed by an untrusted party.</string>
+    <string name="mesh_warn_consent">Consensual forensics can involve access to sensitive information. Only proceed with analysts you trust, and agree in advance on the scope of access.</string>
+    <string name="mesh_warn_adb">If ADB remains enabled, it may be misused by anyone with physical or network access to your device. Disable ADB immediately after a session.</string>
+    <string name="mesh_onb_welcome_eyebrow">Secure forensics, with consent</string>
+    <string name="mesh_onb_welcome_body">MESH lets a trusted analyst privately and securely check your phone for spyware — only when you say so, and only for as long as you allow.</string>
+    <string name="mesh_onb_welcome_tag">Open-source · independently audited</string>
+    <string name="mesh_onb_how_eyebrow">How it works</string>
+    <string name="mesh_onb_how_title">A private link, just for the session</string>
+    <string name="mesh_onb_how_body">MESH builds a direct, end-to-end encrypted connection between your phone and your analyst — nothing in between can read it.</string>
+    <string name="mesh_onb_how_b1">End-to-end encrypted with WireGuard</string>
+    <string name="mesh_onb_how_b2">Connects peer-to-peer, even behind firewalls or mobile networks</string>
+    <string name="mesh_onb_how_b3">The app collects no data and keeps no servers running</string>
+    <string name="mesh_onb_how_b4">The link exists only while a session is active</string>
+    <string name="mesh_onb_consent_eyebrow">You\'re in control</string>
+    <string name="mesh_onb_consent_title">Nothing happens without your OK</string>
+    <string name="mesh_onb_consent_body">Before a session, you and your analyst agree on what they can look at. With your consent, they may:</string>
+    <string name="mesh_onb_consent_b1">Review selected logs and app data together with you</string>
+    <string name="mesh_onb_consent_b2">Run trusted tools that scan for known spyware</string>
+    <string name="mesh_onb_consent_b3">Back up specific apps if you both agree</string>
+    <string name="mesh_onb_consent_note">You decide when access turns on and off. You can end the session in one tap, anytime.</string>
+
+    <!-- Home -->
+    <string name="mesh_status_connected_enc">Connected &amp; encrypted</string>
+    <string name="mesh_status_not_connected">Not connected</string>
+    <string name="mesh_home_conn_title">Secure session active</string>
+    <string name="mesh_home_disc_title">No session running</string>
+    <string name="mesh_home_conn_body">You are privately connected to your analyst. You can end this at any time.</string>
+    <string name="mesh_home_disc_body">Your phone is private. Nothing is shared until you start a session and approve it.</string>
+    <string name="mesh_start_cta">Start a secure session</string>
+    <string name="mesh_end_cta">End session</string>
+    <string name="mesh_analyst_label">Working with you</string>
+    <string name="mesh_analyst_placeholder">Your analyst</string>
+    <string name="mesh_tile_encrypted_title">Encrypted</string>
+    <string name="mesh_tile_encrypted_sub">WireGuard E2E</string>
+    <string name="mesh_tile_notrack_title">No tracking</string>
+    <string name="mesh_tile_notrack_sub">Zero data kept</string>
+    <string name="mesh_tile_control_title">Your control</string>
+    <string name="mesh_tile_control_sub">End anytime</string>
+    <string name="mesh_learn_card_title">How a session works</string>
+    <string name="mesh_learn_card_sub">What your analyst can and can\'t do</string>
+    <string name="mesh_exit_node">Exit node</string>
+    <string name="mesh_exit_node_none">None — traffic stays direct</string>
+    <string name="mesh_adb_on_title">Wireless debugging is on</string>
+    <string name="mesh_adb_on_sub">Your phone is ready to connect</string>
+    <string name="mesh_adb_off_title">Set up wireless debugging</string>
+    <string name="mesh_adb_off_sub">Required so your analyst can connect over Wi-Fi</string>
+
+    <!-- End-session confirm -->
+    <string name="mesh_end_confirm_title">End the secure session?</string>
+    <string name="mesh_end_confirm_body">Your analyst will be disconnected immediately and the encrypted link is torn down. Nothing stays running.</string>
+    <string name="mesh_keep_session">Keep session running</string>
+
+    <!-- Settings -->
+    <string name="mesh_topbar_settings">Settings</string>
+    <string name="mesh_set_group_connection">Connection</string>
+    <string name="mesh_set_control_server">Control server</string>
+    <string name="mesh_set_not_configured">Not configured</string>
+    <string name="mesh_set_exit_node">Exit node</string>
+    <string name="mesh_set_exit_node_sub">Route your traffic through a peer</string>
+    <string name="mesh_set_group_network">Network</string>
+    <string name="mesh_set_magic_dns">Magic DNS</string>
+    <string name="mesh_set_magic_dns_sub">Resolve devices by name on your mesh</string>
+    <string name="mesh_set_split">App split tunneling</string>
+    <string name="mesh_set_split_sub">Choose which apps use MESH</string>
+    <string name="mesh_set_group_privacy">Privacy</string>
+    <string name="mesh_set_obfuscation">Disguise traffic (AmneziaWG)</string>
+    <string name="mesh_set_obfuscation_sub">Hide the connection from network censors</string>
+    <string name="mesh_set_group_about">About</string>
+    <string name="mesh_set_version">MESH v%1$s</string>
+    <string name="mesh_set_source">View source on GitHub</string>
+    <string name="mesh_set_license">Open-source license</string>
+    <string name="mesh_set_license_sub">AGPL-3.0-or-later</string>
+    <string name="mesh_set_group_danger">Danger zone</string>
+    <string name="mesh_set_forget">Forget enrollment</string>
+    <string name="mesh_set_forget_sub">Sign out and remove this device from the network</string>
+    <string name="mesh_set_footer">MESH · the app collects no data</string>
+
+    <!-- Learn -->
+    <string name="mesh_learn_topbar">How a session works</string>
+    <string name="mesh_learn_intro">A session is a temporary, private connection between your phone and a forensics analyst you trust. Here\'s the whole thing, start to finish.</string>
+    <string name="mesh_learn_s1_title">You start a session</string>
+    <string name="mesh_learn_s1_body">Scan your analyst\'s QR or enter a short code. Nothing connects until you do this.</string>
+    <string name="mesh_learn_s2_title">A private link is built</string>
+    <string name="mesh_learn_s2_body">Your phone and the analyst connect directly, end-to-end encrypted. No one in between can read it.</string>
+    <string name="mesh_learn_s3_title">You stay informed</string>
+    <string name="mesh_learn_s3_body">You can watch your connection status live, and the analyst only works within the limits you agreed to beforehand.</string>
+    <string name="mesh_learn_s4_title">You end it, anytime</string>
+    <string name="mesh_learn_s4_body">One tap tears down the link. Wireless debugging switches back off. Nothing keeps running.</string>
+
+    <!-- ADB setup -->
+    <string name="mesh_adb_topbar">Wireless debugging</string>
+    <string name="mesh_adb_title">Let your analyst connect over Wi-Fi</string>
+    <string name="mesh_adb_intro">This is an Android feature called wireless debugging. Follow these steps once — you can turn it off again as soon as you\'re done.</string>
+    <string name="mesh_adb_callout_menus">Menu names differ slightly across phones (e.g. \"About phone\" → \"Software information\"). The steps are the same.</string>
+    <string name="mesh_adb_callout_warn">Only keep wireless debugging on while you\'re working with your analyst. Turn it off afterwards.</string>
+    <string name="mesh_adb_open_settings">Open settings</string>
+    <string name="mesh_adb_its_on">It\'s on</string>
+    <string name="mesh_adb_s1_title">Open system Settings</string>
+    <string name="mesh_adb_s1_body">Go to Settings → About phone → Software information.</string>
+    <string name="mesh_adb_s2_title">Enable Developer options</string>
+    <string name="mesh_adb_s2_body">Find \"Build number\" and tap it 7 times. Enter your PIN if asked.</string>
+    <string name="mesh_adb_s3_title">Open Developer options</string>
+    <string name="mesh_adb_s3_body">Use the button below to jump there, or find it under Settings → System.</string>
+    <string name="mesh_adb_s4_title">Turn on Wireless debugging</string>
+    <string name="mesh_adb_s4_body">Inside Developer options, switch on \"Wireless debugging\".</string>
+    <string name="mesh_adb_s5_title">Come back here</string>
+    <string name="mesh_adb_s5_body">Return to MESH and continue your session setup.</string>
+    <string name="mesh_adb_toast_need_r">Wireless debugging requires Android 11 or higher</string>
+    <string name="mesh_adb_toast_navigate">Navigate to System → Developer options → Wireless debugging</string>
+    <string name="mesh_adb_toast_unable">Unable to open settings. Please enable Wireless debugging manually.</string>
+
 </resources>


### PR DESCRIPTION
- new Compose package (ui/view/mesh): onboarding, home, learn, settings, ADB-setup screens + shared components/icons
- move strings to strings.xml 
- warm theme tokens + MeshMono/MeshSans type
- analyst model + blank-state defaults 
- adds source/license URL constants 