### PR TITLE
refactor: remove android sdk installation

### DIFF
--- a/analyst/Dockerfile
+++ b/analyst/Dockerfile
@@ -23,6 +23,7 @@ RUN ./analyst/src/build.sh
 FROM debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        adb \
         iptables \
         iproute2 \
         iputils-ping \
@@ -37,9 +38,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && mkdir -p /home/mesh/.tailscale \
     && chown -R mesh:mesh /home/mesh \
     && setcap cap_net_admin,cap_net_raw+eip /usr/bin/tcpdump
-
-RUN apt-get install -y --no-install-recommends adb \
-    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build       /usr/src/app/analyst/tailscaled  /usr/bin/tailscaled
 COPY --from=build       /usr/src/app/analyst/tailscale   /usr/bin/tailscale

--- a/analyst/Dockerfile
+++ b/analyst/Dockerfile
@@ -20,29 +20,7 @@ COPY analyst ./analyst
 COPY tailscale ./tailscale
 RUN ./analyst/src/build.sh
 
-FROM eclipse-temurin:25-jre@sha256:04262e8782d6b034ee5d7c1c5d4e8938fcf2063a76b4bfcd84e5d994d09c27bc AS android-sdk
-
-ARG ANDROID_TOOLS_VERSION=14742923
-ARG ANDROID_TOOLS_SUM=04453066b540409d975c676d781da1477479dde3761310f1a7eb92a1dfb15af7
-ENV ANDROID_SDK_ROOT=/usr/local/android-sdk
-
-RUN apt-get update && apt-get install -y --no-install-recommends wget unzip \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir -p "${ANDROID_SDK_ROOT}/tmp" \
-    && wget --progress=dot:giga -O "${ANDROID_SDK_ROOT}/tmp/commandlinetools.zip" \
-        "https://dl.google.com/android/repository/commandlinetools-linux-${ANDROID_TOOLS_VERSION}_latest.zip" \
-    && echo "${ANDROID_TOOLS_SUM}  ${ANDROID_SDK_ROOT}/tmp/commandlinetools.zip" | sha256sum --strict --check - \
-    && unzip -q "${ANDROID_SDK_ROOT}/tmp/commandlinetools.zip" -d "${ANDROID_SDK_ROOT}/tmp" \
-    && mkdir -p "${ANDROID_SDK_ROOT}/cmdline-tools" \
-    && mv "${ANDROID_SDK_ROOT}/tmp/cmdline-tools" "${ANDROID_SDK_ROOT}/cmdline-tools/latest" \
-    && rm -rf "${ANDROID_SDK_ROOT}/tmp" \
-    && yes | "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" --licenses || true \
-    && "${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager" "platform-tools"
-
 FROM debian:bookworm-slim@sha256:0104b334637a5f19aa9c983a91b54c89887c0984081f2068983107a6f6c21eeb
-
-ENV ANDROID_SDK_ROOT=/usr/local/android-sdk
-ENV PATH="${ANDROID_SDK_ROOT}/platform-tools:${PATH}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         iptables \
@@ -60,23 +38,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && chown -R mesh:mesh /home/mesh \
     && setcap cap_net_admin,cap_net_raw+eip /usr/bin/tcpdump
 
-COPY --from=android-sdk /usr/local/android-sdk/platform-tools ${ANDROID_SDK_ROOT}/platform-tools
-
-# The Android SDK ships x86_64 adb for Linux. On ARM64 replace it with the native Debian build.
-RUN arch="$(dpkg --print-architecture)" \
-    && if [ "$arch" = "arm64" ]; then \
-        apt-get update \
-        && apt-get install -y --no-install-recommends adb \
-        && cp /usr/bin/adb "${ANDROID_SDK_ROOT}/platform-tools/adb" \
-        && rm -rf /var/lib/apt/lists/*; \
-    fi
+RUN apt-get install -y --no-install-recommends adb \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=build       /usr/src/app/analyst/tailscaled  /usr/bin/tailscaled
 COPY --from=build       /usr/src/app/analyst/tailscale   /usr/bin/tailscale
-COPY --from=build       /usr/src/app/analyst/mesh  /usr/bin/mesh
-COPY --chmod=755        analyst/entrypoint.sh                 /usr/bin/entrypoint.sh
-COPY --chown=mesh:mesh  analyst/bashrc                        /home/mesh/.bashrc
-COPY                    analyst/amneziawg.conf.example        /etc/mesh/amneziawg.conf.example
+COPY --from=build       /usr/src/app/analyst/mesh        /usr/bin/mesh
+COPY --chmod=755        analyst/entrypoint.sh            /usr/bin/entrypoint.sh
+COPY --chown=mesh:mesh  analyst/bashrc                   /home/mesh/.bashrc
+COPY                    analyst/amneziawg.conf.example   /etc/mesh/amneziawg.conf.example
 
 # No USER directive. The entrypoint drops to mesh after fixing volume perms.
 WORKDIR /home/mesh


### PR DESCRIPTION
Remove the full Android sdk from being installed in the mesh analyst container, we only require adb for functionality