### PR TITLE
feat: use control plane URL set in .env file when generating mobile node keys

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -129,6 +129,7 @@ tasks:
       - printf "\033[1;32mDomain name set to {{.CONTROL_PLANE_DOMAIN_ONLY}}.\033[0m\n\n"
       - echo "CONTROL_PLANE_DOMAIN={{.CONTROL_PLANE_DOMAIN_ONLY}}" >> .env
       - echo "CORS_ORIGIN={{.CORS_ORIGIN | default .DEFAULT_CORS_ORIGIN }}" >> .env
+      - echo "CONTROL_PLANE_URL=https://{{.CONTROL_PLANE_DOMAIN_ONLY}}" >> .env
     deps:
       - createDotEnv
 

--- a/compose.yml
+++ b/compose.yml
@@ -19,11 +19,12 @@ services:
     environment:
       - CORS_ORIGIN=${CORS_ORIGIN:-*}
       - NGINX_MODE=${NGINX_MODE:-prod}
+      - CONTROL_PLANE_URL=${CONTROL_PLANE_URL}
     depends_on:
       - headscale
     ports:
       - "127.0.0.1:80:8080"
-    entrypoint: /bin/sh -c "envsubst '$$CORS_ORIGIN $$NGINX_MODE' < /etc/nginx/nginx.conf.template > /tmp/nginx.conf && nginx -c /tmp/nginx.conf -g 'daemon off;'"
+    entrypoint: /bin/sh -c "envsubst '$$CORS_ORIGIN $$NGINX_MODE $$CONTROL_PLANE_URL' < /etc/nginx/nginx.conf.template > /tmp/nginx.conf && nginx -c /tmp/nginx.conf -g 'daemon off;'"
 
   analyst:
     build:

--- a/control-plane/mesh-ui/src/api/useConfig.ts
+++ b/control-plane/mesh-ui/src/api/useConfig.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+
+export function useControlPlaneUrl() {
+    return useQuery({
+        queryKey: ['config'],
+        queryFn: async () => {
+            const response = await fetch('/config.json')
+            if (!response.ok) return ''
+            const config = await response.json()
+            return config.controlPlaneUrl ?? ''
+        }
+    })
+}

--- a/control-plane/mesh-ui/src/components/GenerateKeyDialog.tsx
+++ b/control-plane/mesh-ui/src/components/GenerateKeyDialog.tsx
@@ -7,6 +7,7 @@ import { useCreatePreAuthKey } from '../api/usePreAuthKeys'
 import { Copy, Check } from 'lucide-react'
 import { encrypt } from '../lib/onboardingCrypto'
 import { QRCodeCanvas } from 'qrcode.react'
+import { useControlPlaneUrl } from '@/api/useConfig'
 
 interface GenerateKeyDialogProps {
   open: boolean
@@ -36,7 +37,9 @@ export function GenerateKeyDialog({ open, onOpenChange, networkName }: GenerateK
   const [intent, setIntent] = useState<string | null>(null)
   const [pin, setPin] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
-  const [controlPlaneURL, setControlPlaneURL] = useState('')
+  const { data: configUrl = '' } = useControlPlaneUrl()
+  const [controlPlaneURLOverride, setControlPlaneURL] = useState<string | null>(null)
+  const controlPlaneURL = controlPlaneURLOverride ?? configUrl
   const [urlError, setUrlError] = useState('')
   const [intentError, setIntentError] = useState('')
   const createKey = useCreatePreAuthKey()

--- a/control-plane/nginx.conf
+++ b/control-plane/nginx.conf
@@ -97,6 +97,11 @@ http {
             proxy_pass http://headscale:8080;
         }
 
+        location = /config.json {
+            default_type application/json;
+            return 200 '{"controlPlaneUrl":"${CONTROL_PLANE_URL}"}';
+        }
+
         location / {
             if ($should_proxy = 1) {
                 proxy_pass http://localhost:3000;


### PR DESCRIPTION
Add new /config.json for the UI and populate with CONTROL_PLANE_URL set during Control Plane configuration. 
This value is used to pre-populate the control plane url when generating keys for mobile nodes.

resolves #173 