### PR TITLE
Feat/frp provisioning api

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -13,8 +13,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - run: go test ./provisioning/...

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -1,0 +1,20 @@
+name: Provisioning Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'provisioning/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/provisioning-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go test ./provisioning/...

--- a/provisioning/.gitignore
+++ b/provisioning/.gitignore
@@ -1,0 +1,1 @@
+provisioner.env

--- a/provisioning/Dockerfile
+++ b/provisioning/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.26-alpine AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -o provisioner ./provisioning/cmd/server
+
+FROM scratch
+COPY --from=builder /app/provisioner /provisioner
+EXPOSE 8080
+ENTRYPOINT ["/provisioner"]

--- a/provisioning/cmd/server/main.go
+++ b/provisioning/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -36,7 +37,7 @@ func main() {
 	}
 
 	portMax := os.Getenv("FRPS_PORT_MAX")
-	if portMin == "" {
+	if portMax == "" {
 		log.Fatal("FRPS_PORT_MAX must be set")
 	}
 	portMaxInt, err := strconv.Atoi(portMax)
@@ -44,7 +45,7 @@ func main() {
 		log.Fatal("failed to parse FRPS_PORT_MAX")
 	}
 
-	registry, err := state.New("/var/lib/mesh-provisioner/state.json", portMinInt, portMaxInt)
+	registry, err := state.New(filepath.Join(os.TempDir(), "state.json"), portMinInt, portMaxInt)
 	if err != nil {
 		log.Fatal("failed to initialise port registry")
 	}

--- a/provisioning/cmd/server/main.go
+++ b/provisioning/cmd/server/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/BARGHEST-ngo/MESH/provisioning/internal/api"
+)
+
+// This is an intentionally light-weight and basic HTTP server
+// Don't want to over-engineer at this stage, just prove it works
+func main() {
+	// PROVISIONING_API_KEY during early dev will be a single shared secret
+	// Internal use only during development
+	// Moving to per-customer keys as we get closer to prod
+	apiKey := os.Getenv("PROVISIONING_API_KEY")
+	if apiKey == "" {
+		log.Fatal("PROVISIONING_API_KEY must be set")
+	}
+
+	srv := &http.Server{
+		Addr:         ":8080",
+		Handler:      api.NewRouter(apiKey),
+		ReadTimeout:  10 * time.Second,
+		WriteTimeout: 10 * time.Second,
+	}
+
+	go func() {
+		log.Printf("provisioner listening on :8080")
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("listen: %v", err)
+		}
+	}()
+
+	quit := make(chan os.Signal, 1)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	<-quit
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Printf("shutdown: %v", err)
+	}
+}

--- a/provisioning/cmd/server/main.go
+++ b/provisioning/cmd/server/main.go
@@ -6,10 +6,12 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strconv"
 	"syscall"
 	"time"
 
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/api"
+	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
 )
 
 // This is an intentionally light-weight and basic HTTP server
@@ -23,9 +25,33 @@ func main() {
 		log.Fatal("PROVISIONING_API_KEY must be set")
 	}
 
+	portMin := os.Getenv("FRPS_PORT_MIN")
+	if portMin == "" {
+		log.Fatal("FRPS_PORT_MIN must be set")
+	}
+
+	portMinInt, err := strconv.Atoi(portMin)
+	if err != nil {
+		log.Fatal("FRPS_PORT_MIN must be set")
+	}
+
+	portMax := os.Getenv("FRPS_PORT_MAX")
+	if portMin == "" {
+		log.Fatal("FRPS_PORT_MIN must be set")
+	}
+	portMaxInt, err := strconv.Atoi(portMax)
+	if err != nil {
+		log.Fatal("FRPS_PORT_MIN must be set")
+	}
+
+	registry, err := state.New("", portMinInt, portMaxInt)
+	if err != nil {
+		log.Fatal("failed to initialise port registry")
+	}
+
 	srv := &http.Server{
 		Addr:         ":8080",
-		Handler:      api.NewRouter(apiKey),
+		Handler:      api.NewRouter(apiKey, registry),
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 10 * time.Second,
 	}

--- a/provisioning/cmd/server/main.go
+++ b/provisioning/cmd/server/main.go
@@ -32,19 +32,19 @@ func main() {
 
 	portMinInt, err := strconv.Atoi(portMin)
 	if err != nil {
-		log.Fatal("FRPS_PORT_MIN must be set")
+		log.Fatal("failed to parse FRPS_PORT_MIN")
 	}
 
 	portMax := os.Getenv("FRPS_PORT_MAX")
 	if portMin == "" {
-		log.Fatal("FRPS_PORT_MIN must be set")
+		log.Fatal("FRPS_PORT_MAX must be set")
 	}
 	portMaxInt, err := strconv.Atoi(portMax)
 	if err != nil {
-		log.Fatal("FRPS_PORT_MIN must be set")
+		log.Fatal("failed to parse FRPS_PORT_MAX")
 	}
 
-	registry, err := state.New("", portMinInt, portMaxInt)
+	registry, err := state.New("/var/lib/mesh-provisioner/state.json", portMinInt, portMaxInt)
 	if err != nil {
 		log.Fatal("failed to initialise port registry")
 	}

--- a/provisioning/compose.yml
+++ b/provisioning/compose.yml
@@ -1,0 +1,10 @@
+services:
+  provisioner:
+    build:
+      context: ../
+      dockerfile: provisioning/Dockerfile
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8081:8080"
+    env_file:
+      - provisioner.env

--- a/provisioning/compose.yml
+++ b/provisioning/compose.yml
@@ -8,3 +8,8 @@ services:
       - "127.0.0.1:8081:8080"
     env_file:
       - provisioner.env
+    volumes:
+      - provisioner-state:/var/lib/mesh-provisioner
+
+volumes:
+  provisioner-state:

--- a/provisioning/internal/api/auth_test.go
+++ b/provisioning/internal/api/auth_test.go
@@ -1,0 +1,44 @@
+package api
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAuthRequest(t *testing.T) {
+	keyHash := sha256.Sum256([]byte("test-key"))
+
+	dummy := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := authRequest(keyHash, dummy)
+
+	cases := []struct {
+		name     string
+		token    string
+		expected int
+	}{
+		{"no token", "", http.StatusUnauthorized},
+		{"wrong token", "wrong-key", http.StatusUnauthorized},
+		{"valid token", "test-key", http.StatusOK},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/dummy", nil)
+			if tc.token != "" {
+				req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tc.token))
+			}
+			w := httptest.NewRecorder()
+			handler.ServeHTTP(w, req)
+
+			if w.Code != tc.expected {
+				t.Errorf("expected %d, got %d", tc.expected, w.Code)
+			}
+		})
+	}
+}

--- a/provisioning/internal/api/deployment.go
+++ b/provisioning/internal/api/deployment.go
@@ -10,7 +10,7 @@ import (
 
 // Provision a new frp container
 // Generate subdomain slug, token & return to client
-func handlePostDeployment(w http.ResponseWriter, r *http.Request) {
+func (h *handler) handlePostDeployment(w http.ResponseWriter, r *http.Request) {
 	slug, err := generateSlug()
 	if err != nil {
 		// write error
@@ -23,10 +23,18 @@ func handlePostDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	port, err := h.registry.AllocatePort(slug, token)
+	if err != nil {
+		//write error
+		return
+	}
+
+	// start container
+
 	response := &DeploymentResponse{
-		Slug:  slug,
-		Token: token,
-		
+		Slug:     slug,
+		Token:    token,
+		FrpsPort: port,
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
@@ -44,4 +52,4 @@ func generateToken() (string, error) {
 	return base64.RawURLEncoding.EncodeToString(b), err
 }
 
-func handleDeleteDeployment(w http.ResponseWriter, r *http.Request) {}
+func (h *handler) handleDeleteDeployment(w http.ResponseWriter, r *http.Request) {}

--- a/provisioning/internal/api/deployment.go
+++ b/provisioning/internal/api/deployment.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
@@ -13,19 +14,19 @@ import (
 func (h *handler) handlePostDeployment(w http.ResponseWriter, r *http.Request) {
 	slug, err := generateSlug()
 	if err != nil {
-		// write error
+		http.Error(w, "failed to generate slug", http.StatusInternalServerError)
 		return
 	}
 
 	token, err := generateToken()
 	if err != nil {
-		// write error
+		http.Error(w, "failed to generate token", http.StatusInternalServerError)
 		return
 	}
 
 	port, err := h.registry.AllocatePort(slug, token)
 	if err != nil {
-		//write error
+		http.Error(w, fmt.Sprintf("failed to allocate port: %v", err), http.StatusInternalServerError)
 		return
 	}
 

--- a/provisioning/internal/api/deployment.go
+++ b/provisioning/internal/api/deployment.go
@@ -1,0 +1,13 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Provision a new frp container
+// Generate subdomain slug, token & return to client
+func handleDeployment(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"deployment": "ok"})
+}

--- a/provisioning/internal/api/deployment.go
+++ b/provisioning/internal/api/deployment.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"crypto/rand"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 )
@@ -15,25 +17,31 @@ func handlePostDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	token, err := generateToken()
+	if err != nil {
+		// write error
+		return
+	}
+
 	response := &DeploymentResponse{
-		Slug: slug,
+		Slug:  slug,
+		Token: token,
+		
 	}
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }
 
 func generateSlug() (string, error) {
-	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
-	b := make([]byte, 10)
+	b := make([]byte, 5)
 	_, err := rand.Read(b)
-	if err != nil {
-		return "", err
-	}
+	return hex.EncodeToString(b), err
+}
 
-	for i := range b {
-		b[i] = charset[int(b[i])%len(charset)]
-	}
-	return string(b), nil
+func generateToken() (string, error) {
+	b := make([]byte, 32)
+	_, err := rand.Read(b)
+	return base64.RawURLEncoding.EncodeToString(b), err
 }
 
 func handleDeleteDeployment(w http.ResponseWriter, r *http.Request) {}

--- a/provisioning/internal/api/deployment.go
+++ b/provisioning/internal/api/deployment.go
@@ -1,13 +1,39 @@
 package api
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"net/http"
 )
 
 // Provision a new frp container
 // Generate subdomain slug, token & return to client
-func handleDeployment(w http.ResponseWriter, r *http.Request) {
+func handlePostDeployment(w http.ResponseWriter, r *http.Request) {
+	slug, err := generateSlug()
+	if err != nil {
+		// write error
+		return
+	}
+
+	response := &DeploymentResponse{
+		Slug: slug,
+	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"deployment": "ok"})
+	json.NewEncoder(w).Encode(response)
 }
+
+func generateSlug() (string, error) {
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, 10)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", err
+	}
+
+	for i := range b {
+		b[i] = charset[int(b[i])%len(charset)]
+	}
+	return string(b), nil
+}
+
+func handleDeleteDeployment(w http.ResponseWriter, r *http.Request) {}

--- a/provisioning/internal/api/deployment.go
+++ b/provisioning/internal/api/deployment.go
@@ -37,6 +37,7 @@ func (h *handler) handlePostDeployment(w http.ResponseWriter, r *http.Request) {
 		Token:    token,
 		FrpsPort: port,
 	}
+	w.WriteHeader(http.StatusCreated)
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(response)
 }

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -1,0 +1,74 @@
+package api_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/BARGHEST-ngo/MESH/provisioning/internal/api"
+	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
+)
+
+const testAPIKey = "test-key"
+
+func newTestRouter(t *testing.T) http.Handler {
+	t.Helper()
+	reg, err := state.New(filepath.Join(t.TempDir(), "state.json"), 7001, 7010)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return api.NewRouter(testAPIKey, reg)
+}
+
+func TestPostDeployment(t *testing.T) {
+	cases := []struct {
+		name     string
+		token    string
+		expected int
+		method   string
+	}{
+		{"no token", "", http.StatusUnauthorized, http.MethodPost},
+		{"wrong token", "wrong-token", http.StatusUnauthorized, http.MethodPost},
+		{"valid token", testAPIKey, http.StatusCreated, http.MethodPost},
+		{"invalid method", testAPIKey, http.StatusMethodNotAllowed, http.MethodGet},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "/deployment", nil)
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", tc.token))
+			w := httptest.NewRecorder()
+			newTestRouter(t).ServeHTTP(w, req)
+
+			if w.Code != tc.expected {
+				t.Errorf("expected %d, got %d", tc.expected, w.Code)
+			}
+		})
+	}
+}
+
+func TestPostDeploymentPortExhaustion(t *testing.T) {
+	reg, err := state.New(filepath.Join(t.TempDir(), "state.json"), 7001, 7001)
+	if err != nil {
+		t.Fatal(err)
+	}
+	router := api.NewRouter(testAPIKey, reg)
+
+	makeRequest := func() int {
+		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", testAPIKey))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := makeRequest(); code != http.StatusCreated {
+		t.Fatalf("first request expected %d, got %d", http.StatusCreated, code)
+	}
+
+	if code := makeRequest(); code != http.StatusInternalServerError {
+		t.Errorf("second request expected %d, got %d", http.StatusInternalServerError, code)
+	}
+}

--- a/provisioning/internal/api/handler.go
+++ b/provisioning/internal/api/handler.go
@@ -4,15 +4,21 @@ import (
 	"crypto/sha256"
 	"crypto/subtle"
 	"net/http"
+
+	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
 )
 
-func NewRouter(apiKey string) http.Handler {
-	keyHash := sha256.Sum256([]byte(apiKey))
+type handler struct {
+	registry *state.Registry
+}
 
+func NewRouter(apiKey string, registry *state.Registry) http.Handler {
+	keyHash := sha256.Sum256([]byte(apiKey))
+	h := &handler{registry: registry}
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", handleHealth)
-	mux.HandleFunc("POST /deployment", handlePostDeployment)
-	mux.HandleFunc("DELETE /deployment", handleDeleteDeployment)
+	mux.HandleFunc("POST /deployment", h.handlePostDeployment)
+	mux.HandleFunc("DELETE /deployment/{slug}", h.handleDeleteDeployment)
 
 	return authRequest(keyHash, mux)
 }

--- a/provisioning/internal/api/handler.go
+++ b/provisioning/internal/api/handler.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"net/http"
+)
+
+func NewRouter(apiKey string) http.Handler {
+	keyHash := sha256.Sum256([]byte(apiKey))
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", handleHealth)
+	mux.HandleFunc("POST /deployment", handleDeployment)
+
+	return authRequest(keyHash, mux)
+}
+
+func authRequest(keyHash [32]byte, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/health" {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		bearer := r.Header.Get("Authorization")
+		if len(bearer) < 8 || bearer[:7] != "Bearer " {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		incoming := sha256.Sum256([]byte(bearer[7:]))
+		if subtle.ConstantTimeCompare(incoming[:], keyHash[:]) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}

--- a/provisioning/internal/api/handler.go
+++ b/provisioning/internal/api/handler.go
@@ -11,7 +11,8 @@ func NewRouter(apiKey string) http.Handler {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", handleHealth)
-	mux.HandleFunc("POST /deployment", handleDeployment)
+	mux.HandleFunc("POST /deployment", handlePostDeployment)
+	mux.HandleFunc("DELETE /deployment", handleDeleteDeployment)
 
 	return authRequest(keyHash, mux)
 }

--- a/provisioning/internal/api/health.go
+++ b/provisioning/internal/api/health.go
@@ -1,0 +1,11 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+}

--- a/provisioning/internal/api/types.go
+++ b/provisioning/internal/api/types.go
@@ -1,0 +1,9 @@
+package api
+
+type DeploymentRequest struct{}
+
+type DeploymentResponse struct {
+	Slug     string `json:"slug"`
+	Token    string `json:"token"`
+	FrpsPort int    `json:"frps_port"`
+}

--- a/provisioning/internal/state/registry.go
+++ b/provisioning/internal/state/registry.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 )
@@ -31,6 +32,9 @@ type Registry struct {
 }
 
 func New(path string, portMin, portMax int) (*Registry, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, fmt.Errorf("failed to create state directory: %w", err)
+	}
 	r := &Registry{
 		path:    path,
 		portMin: portMin,

--- a/provisioning/internal/state/registry.go
+++ b/provisioning/internal/state/registry.go
@@ -1,5 +1,8 @@
 package state
 
+// State Registry tracks the internal state of deployments
+// Primarily tracks allocated ports for all started containers
+
 import (
 	"encoding/json"
 	"fmt"

--- a/provisioning/internal/state/registry.go
+++ b/provisioning/internal/state/registry.go
@@ -1,0 +1,109 @@
+package state
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+)
+
+type Deployment struct {
+	Slug      string    `json:"slug"`
+	Token     string    `json:"token"`
+	FrpsPort  int       `json:"frps_port"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type registryState struct {
+	Deployments map[string]Deployment `json:"deployments"`
+}
+
+type Registry struct {
+	mu      sync.Mutex
+	state   registryState
+	path    string
+	portMin int
+	portMax int
+}
+
+func New(path string, portMin, portMax int) (*Registry, error) {
+	r := &Registry{
+		path:    path,
+		portMin: portMin,
+		portMax: portMax,
+		state:   registryState{Deployments: make(map[string]Deployment)},
+	}
+	if err := r.load(); err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (r *Registry) AllocatePort(slug, token string) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	used := make(map[int]bool)
+	for _, d := range r.state.Deployments {
+		used[d.FrpsPort] = true
+	}
+
+	for port := r.portMin; port <= r.portMax; port++ {
+		if !used[port] {
+			r.state.Deployments[slug] = Deployment{
+				Slug:      slug,
+				Token:     token,
+				FrpsPort:  port,
+				CreatedAt: time.Now().UTC(),
+			}
+			return port, r.save()
+		}
+	}
+
+	return 0, fmt.Errorf("no available port")
+}
+
+func (r *Registry) Release(slug string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if _, ok := r.state.Deployments[slug]; !ok {
+		// TODO: Should this silently error?
+		return fmt.Errorf("deployment %s not found", slug)
+	}
+	delete(r.state.Deployments, slug)
+	return r.save()
+}
+
+func (r *Registry) Get(slug string) (Deployment, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	d, ok := r.state.Deployments[slug]
+	return d, ok
+}
+
+func (r *Registry) load() error {
+	data, err := os.ReadFile(r.path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error reading depolyments file: %w", err)
+	}
+	return json.Unmarshal(data, &r.state)
+}
+
+func (r *Registry) save() error {
+	data, err := json.MarshalIndent(r.state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal error: %w", err)
+	}
+
+	tmp := r.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("write file error: %w", err)
+	}
+	return os.Rename(tmp, r.path)
+}


### PR DESCRIPTION
### Summary
#200 
Provisioning API for starting and tearing down new FRP containers for reverse proxy
WIP, want to get some eyes on it early before the change list gets too big.
Purposefully straight forward at the moment, using standard go libraries as much as possible.

### Purpose of this API:
When a user starts a new MESH Control Plane and opts to have the proxy domain automatically configured, this API will provision the frp server container and setup the reverse proxy on the user's behalf.  Users will still have the option to manage their own proxy via ngrok or a service of their choosing.

Current state:
POST /deployment : generates subdomain slug, access token, and allocates a port for the frp container & returns to the caller.
Still to do - Write frps.toml and launch the new container

DELETE /deployment/{slug} - Not implemented. Will tear down any existing frp container for the specified slug

### Local testing
Create `provisioner.env` in `provisioning/`
Populate with example contents:
```
PROVISIONING_API_KEY=foobar123
FRPS_PORT_MIN=7000
FRPS_PORT_MAX=7999
```
`/health`
`curl http://localhost:8081/health`
`{"status":"ok"}`

`POST /deployment`
`curl -X POST -H "Authorization: Bearer foobar123" http://localhost:8081/deployment`
`{"slug":"d0343ae974","token":"1O43tIKMR641BHyK0XH1lkK6fNANL5WRWqWa-m36J2s","frps_port":7000}`