### PR TITLE
chore: unblock dependabot, always run android build on any github worflow change

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -9,7 +9,7 @@ on:
       - 'android-client/**'
       - 'go.mod'
       - 'go.sum'
-      - '.github/workflows/android-release.yml'
+      - '.github/workflows/*'
   workflow_dispatch:  # Allows manual trigger from GitHub UI
     inputs:
       version:


### PR DESCRIPTION
Dependabot (and possibly other) PRs to main are blocked if the android build action does not trigger.  
This should unblock them, but we'll want to review this in the future