### PR TITLE
Feat/tls auto provisioning

### DIFF
--- a/.provisioner.env.example
+++ b/.provisioner.env.example
@@ -1,2 +1,3 @@
-PROVISIONER_URL=https://provisioner.tunnel.meshforensics.app
+PROVISIONER_URL=https://provisioner.tunnel.your-domain.com
 PROVISIONER_API_KEY=random 32 byte api key
+MESH_DOMAIN=your-domain.com

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -162,13 +162,14 @@ tasks:
             -e "s|FRP_PORT|$FRP_PORT|g" \
             -e "s|FRP_AUTH_TOKEN|$FRP_TOKEN|g" \
             -e "s|FRP_SLUG|$FRP_SLUG|g" \
+            -e "s|MESH_DOMAIN|$MESH_DOMAIN|g" \
             control-plane/frpc.toml.example > control-plane/frpc.toml
-        sed -e "s|CONTROL_PLANE_URL|https://$FRP_SLUG.tunnel.meshforensics.app|g" \
+        sed -e "s|CONTROL_PLANE_URL|https://$FRP_SLUG.tunnel.$MESH_DOMAIN|g" \
             control-plane/headscale/config.example.yaml > control-plane/headscale/config.yaml
         echo "MESH_SUBDOMAIN=$FRP_SLUG" >> .env
         echo "FRP_AUTH_TOKEN=$FRP_TOKEN" >> .env
-        echo "CONTROL_PLANE_URL=https://$FRP_SLUG.tunnel.meshforensics.app" >> .env
-        echo "LOGIN_URL=https://$FRP_SLUG.tunnel.meshforensics.app" >> .env
+        echo "CONTROL_PLANE_URL=https://$FRP_SLUG.tunnel.$MESH_DOMAIN" >> .env
+        echo "LOGIN_URL=https://$FRP_SLUG.tunnel.$MESH_DOMAIN" >> .env
     deps:
       - createDotEnv
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,7 +44,17 @@ tasks:
 
   down:
     desc: Stop MESH Docker containers
-    cmd: docker compose down
+    cmds:
+      - |
+        if grep -q "CONTROL_PLANE_TYPE=Ephemeral" .env 2>/dev/null && [ -n "$MESH_SUBDOMAIN" ]; then
+          if ! curl -sf -X DELETE "$PROVISIONER_URL/deployment/$MESH_SUBDOMAIN" -H "Authorization: Bearer $PROVISIONER_API_KEY"; then
+            printf "\033[1;31mFailed to delete deployment $MESH_SUBDOMAIN.\nPlease contact support quoting '$MESH_SUBDOMAIN'.\033[0m\n"
+          else
+            printf "\033[1;32mDeleted deployment $MESH_SUBDOMAIN.\033[0m\n"
+          fi
+        fi
+        docker compose down
+        printf "\033[1;32mControl plane stopped.\033[0m\n"
 
   apikey:
     desc: Generate a Headscale API key

--- a/control-plane/frpc.toml.example
+++ b/control-plane/frpc.toml.example
@@ -8,4 +8,4 @@ name = "mesh"
 type = "http"
 localIP = "ui"
 localPort = 8080
-customDomains = ["FRP_SLUG.tunnel.meshforensics.app"]
+customDomains = ["FRP_SLUG.tunnel.MESH_DOMAIN"]

--- a/provisioning/cmd/server/main.go
+++ b/provisioning/cmd/server/main.go
@@ -56,6 +56,11 @@ func main() {
 		log.Fatal("FRPS_IMAGE must be set")
 	}
 
+	meshDomain := os.Getenv("MESH_DOMAIN")
+	if meshDomain == "" {
+		log.Fatal("MESH_DOMAIN must be set")
+	}
+
 	if err := docker.PullImage(frpsImage); err != nil {
 		log.Fatalf("failed to pull frps image: %v", err)
 	}
@@ -67,7 +72,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:         ":8080",
-		Handler:      api.NewRouter(apiKey, registry, frpsImage),
+		Handler:      api.NewRouter(apiKey, registry, frpsImage, meshDomain),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}

--- a/provisioning/cmd/server/main.go
+++ b/provisioning/cmd/server/main.go
@@ -19,12 +19,12 @@ import (
 // This is an intentionally light-weight and basic HTTP server
 // Don't want to over-engineer at this stage, just prove it works
 func main() {
-	// PROVISIONING_API_KEY during early dev will be a single shared secret
+	// PROVISIONER_API_KEY during early dev will be a single shared secret
 	// Internal use only during development
 	// Moving to per-customer keys as we get closer to prod
-	apiKey := os.Getenv("PROVISIONING_API_KEY")
+	apiKey := os.Getenv("PROVISIONER_API_KEY")
 	if apiKey == "" {
-		log.Fatal("PROVISIONING_API_KEY must be set")
+		log.Fatal("PROVISIONER_API_KEY must be set")
 	}
 
 	portMin := os.Getenv("FRPS_PORT_MIN")

--- a/provisioning/compose.yml
+++ b/provisioning/compose.yml
@@ -16,23 +16,28 @@ services:
       - mesh-proxy
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.provisioner.rule=Host(`provisioner.tunnel.meshforensics.app`)"
+      - "traefik.http.routers.provisioner.rule=Host(`provisioner.tunnel.${MESH_DOMAIN}`)"
       - "traefik.http.routers.provisioner.tls=true"
+      - "traefik.http.routers.provisioner.tls.certresolver=letsencrypt"
       - "traefik.http.services.provisioner.loadbalancer.server.port=8080"
 
   traefik:
     image: traefik:v3.7.5
     restart: unless-stopped
+    env_file:
+      - provisioner.env
     ports:
       - "443:443"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
-      - /etc/ssl/mesh:/certs:ro
       - ./traefik.yml:/etc/traefik/traefik.yml:ro
-      - ./tls.yml:/tls.yml:ro
+      - acme:/acme
     networks:
       - mesh-proxy
 
 networks:
   mesh-proxy:
     name: mesh-proxy
+
+volumes:
+  acme:

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -24,7 +24,7 @@ func newTestRouter(t *testing.T) http.Handler {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return api.NewRouter(testAPIKey, reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
+	return api.NewRouter(testAPIKey, reg, "some_frps_image", "your-domain", api.WithContainerService(mockContainerService{}))
 }
 
 func TestPostDeployment(t *testing.T) {
@@ -59,7 +59,7 @@ func TestPostDeploymentPortExhaustion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	router := api.NewRouter(testAPIKey, reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
+	router := api.NewRouter(testAPIKey, reg, "some_frps_image", "your-domain", api.WithContainerService(mockContainerService{}))
 
 	makeRequest := func() int {
 		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)

--- a/provisioning/internal/api/handler.go
+++ b/provisioning/internal/api/handler.go
@@ -25,12 +25,13 @@ type ContainerService interface {
 	Stop(slug string) error
 }
 
-func NewRouter(apiKey string, registry *state.Registry, frpsImage string, opts ...Option) http.Handler {
+func NewRouter(apiKey string, registry *state.Registry, frpsImage, meshDomain string, opts ...Option) http.Handler {
 	keyHash := sha256.Sum256([]byte(apiKey))
 	h := &handler{
 		registry: registry,
 		service: docker.Manager{
-			FrpsImage: frpsImage,
+			FrpsImage:  frpsImage,
+			MeshDomain: meshDomain,
 		},
 	}
 	for _, opt := range opts {

--- a/provisioning/internal/docker/container.go
+++ b/provisioning/internal/docker/container.go
@@ -48,12 +48,6 @@ func (m Manager) Start(d state.Deployment) error {
 	defer client.Close()
 
 	ctx := context.Background()
-	output, err := client.ImagePull(ctx, m.FrpsImage, image.PullOptions{})
-	if err != nil {
-		return fmt.Errorf("failed to pull frps image: %w", err)
-	}
-	io.Copy(io.Discard, output)
-	output.Close()
 	resp, err := client.ContainerCreate(ctx,
 		&container.Config{
 			Image: m.FrpsImage,

--- a/provisioning/internal/docker/container.go
+++ b/provisioning/internal/docker/container.go
@@ -16,7 +16,8 @@ import (
 )
 
 type Manager struct {
-	FrpsImage string
+	FrpsImage  string
+	MeshDomain string
 }
 
 func PullImage(imageName string) error {
@@ -59,10 +60,13 @@ func (m Manager) Start(d state.Deployment) error {
 			Image: m.FrpsImage,
 			Labels: map[string]string{
 				"traefik.enable": "true",
-				fmt.Sprintf("traefik.http.routers.%s.rule", d.Slug):                      fmt.Sprintf("Host(`%s.tunnel.meshforensics.app`)", d.Slug),
+				fmt.Sprintf("traefik.http.routers.%s.rule", d.Slug):                      fmt.Sprintf("Host(`%s.tunnel.%s`)", d.Slug, m.MeshDomain),
 				fmt.Sprintf("traefik.http.routers.%s.tls", d.Slug):                       "true",
+				fmt.Sprintf("traefik.http.routers.%s.tls.certresolver", d.Slug):          "letsencrypt",
+				fmt.Sprintf("traefik.http.routers.%s.tls.domains[0].main", d.Slug):       "tunnel." + m.MeshDomain,
+				fmt.Sprintf("traefik.http.routers.%s.tls.domains[0].sans", d.Slug):       "*.tunnel." + m.MeshDomain,
 				fmt.Sprintf("traefik.http.services.%s.loadbalancer.server.port", d.Slug): "8080",
-				"traefik.docker.network":                                                 "mesh-proxy",
+				"traefik.docker.network": "mesh-proxy",
 			},
 		},
 		&container.HostConfig{

--- a/provisioning/internal/docker/container.go
+++ b/provisioning/internal/docker/container.go
@@ -10,7 +10,6 @@ import (
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/image"
-	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 )
@@ -76,14 +75,13 @@ func (m Manager) Start(d state.Deployment) error {
 				nat.Port("7000/tcp"): []nat.PortBinding{{HostPort: fmt.Sprintf("%d", d.FrpsPort)}},
 			},
 		},
-		&network.NetworkingConfig{
-			EndpointsConfig: map[string]*network.EndpointSettings{
-				"mesh-proxy": {},
-			},
-		},
-		nil, fmt.Sprintf("frps-%s", d.Slug))
+		nil, nil, fmt.Sprintf("frps-%s", d.Slug))
 	if err != nil {
 		return fmt.Errorf("failed to create container: %w", err)
+	}
+
+	if err := client.NetworkConnect(ctx, "mesh-proxy", resp.ID, nil); err != nil {
+		return fmt.Errorf("failed to connect container to mesh-proxy network: %w", err)
 	}
 
 	return client.ContainerStart(ctx, resp.ID, container.StartOptions{})

--- a/provisioning/provisioner.env.example
+++ b/provisioning/provisioner.env.example
@@ -1,7 +1,7 @@
 FRPS_IMAGE=snowdreamtech/frps:latest
 FRPS_PORT_MIN=7000
 FRPS_PORT_MAX=7100
-PROVISIONER_API_KEY=random 32 byte api key
+PROVISIONING_API_KEY=random 32 byte api key
 MESH_DOMAIN=your-domain.com
 TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL=porkbun account email
 PORKBUN_API_KEY=generated in porkbun account settings

--- a/provisioning/provisioner.env.example
+++ b/provisioning/provisioner.env.example
@@ -1,7 +1,7 @@
 FRPS_IMAGE=snowdreamtech/frps:latest
 FRPS_PORT_MIN=7000
 FRPS_PORT_MAX=7100
-PROVISIONING_API_KEY=random 32 byte api key
+PROVISIONER_API_KEY=random 32 byte api key
 MESH_DOMAIN=your-domain.com
 TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL=porkbun account email
 PORKBUN_API_KEY=generated in porkbun account settings

--- a/provisioning/provisioner.env.example
+++ b/provisioning/provisioner.env.example
@@ -1,0 +1,8 @@
+FRPS_IMAGE=snowdreamtech/frps:latest
+FRPS_PORT_MIN=7000
+FRPS_PORT_MAX=7100
+PROVISIONER_API_KEY=random 32 byte api key
+MESH_DOMAIN=your-domain.com
+TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL=porkbun account email
+PORKBUN_API_KEY=generated in porkbun account settings
+PORKBUN_SECRET_API_KEY=generated in porkbun account settings

--- a/provisioning/tls.yml
+++ b/provisioning/tls.yml
@@ -1,4 +1,0 @@
-tls:
-  certificates:
-    - certFile: /certs/domain.cert.pem
-      keyFile: /certs/private.key.pem

--- a/provisioning/traefik.yml
+++ b/provisioning/traefik.yml
@@ -2,12 +2,19 @@ entryPoints:
   websecure:
     address: ":443"
 
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      storage: /acme/acme.json
+      dnsChallenge:
+        provider: porkbun
+        resolvers: 
+          - "1.1.1.1:53"
+
 providers:
   docker:
     exposedByDefault: false
     network: mesh-proxy
-  file:
-    filename: /tls.yml
 
 log:
   level: INFO


### PR DESCRIPTION
#184 

## Summary
End-to-end test for provisioning proxies for the MESH network

## Testing
- Create `.provisioner.env` file at root - reach out to @DWoodhouse22 for details
- clean up any existing Control Plane deployments
  - `task down && rm .env`
- `task controlPlane`
- Choose ephemeral
- Once done, control plane should be accessible at the URL in the task output
- `task down` to stop local containers and remove the frps deployment from the server

Todo:
- Register analyst and mobile devices to the network and confirm reachability
- Investigate ways to add a TTL or other means to clean stale deployments from the server
- Per-customer API keys so we can put limits on use and revoke access