### PR TITLE
chore: clean .env when calling task down

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -54,6 +54,7 @@ tasks:
             printf "\033[1;32mDeleted deployment $MESH_SUBDOMAIN.\033[0m\n"
           fi
         fi
+        rm -f .env
         docker compose down
         printf "\033[1;32mControl plane stopped.\033[0m\n"
 


### PR DESCRIPTION
Deletes .env when MESH is torn down, ready for the next deployment.  Deployments are ephemeral so there's no need to keep this file and only adds to confusion - manual process to delete