### PR TITLE
chore:silently ignore blank auth key value

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -53,7 +53,7 @@ services:
       - analyst-data:/home/mesh/.tailscale
     environment:
       - LOGIN_URL=${LOGIN_URL:-https://${CONTROL_PLANE_DOMAIN}}
-      - AUTH_KEY=${AUTH_KEY}
+      - AUTH_KEY=${AUTH_KEY:-}
       - MESH_PORT=${MESH_PORT:-41641}
 
 volumes:


### PR DESCRIPTION
Compose throws a warning which isn't harmful but it's noisy and confusing. AUTH_KEY is fine to be blank at this stage, it's set by the user when starting the analyst tool.  The variable needs to exist here as it's used by the entrypoint script when setting up tailscale, could probably review if this actually needs to exist but this is fine for now.  