### PR TITLE
Generate API Key automatically

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,9 +26,9 @@ tasks:
   controlPlane:
     desc: Start MESH control plane
     cmds:
-      - cmd: docker compose up -d headscale ui frpc
+      - cmd: docker compose up -d --wait headscale ui frpc
         if: 'grep -q "CONTROL_PLANE_TYPE=Ephemeral" .env 2>/dev/null'
-      - cmd: docker compose up -d headscale ui
+      - cmd: docker compose up -d --wait headscale ui
         if: '! grep -q "CONTROL_PLANE_TYPE=Ephemeral" .env 2>/dev/null'
       - task: generateAuthKey
     deps:
@@ -97,11 +97,11 @@ tasks:
     internal: true
     cmds:
       - |
-        printf "Waiting for headscale...\n"
-        for i in $(seq 10); do
-          docker compose exec -T headscale headscale version >/dev/null 2>&1 && break
-          sleep 1
-        done
+        # printf "Waiting for headscale...\n"
+        # for i in $(seq 10); do
+        #   docker compose exec -T headscale headscale version >/dev/null 2>&1 && break
+        #   sleep 1
+        # done
         KEY=$(docker compose exec -T headscale headscale apikeys create --expiration {{.API_KEY_EXPIRATION}})
         printf "\033[1;37mControl plane API key (enter this in the web UI to log in):\033[0m\n"
         printf "\033[1;32m$KEY\033[0m\n"
@@ -141,9 +141,9 @@ tasks:
     if: 'grep -q "CONTROL_PLANE_TYPE=Ephemeral" .env 2>/dev/null'
     cmds:
       - |
-        printf "\033[1;36m╔═══════════════════════════════════╗\033[0m\n"
+        printf "\033[1;36m╔══════════════════════════════════════════════════════════════════╗\033[0m\n"
         printf "\033[1;36m║\033[0m\033[1;37m Choose a domain for your network: \033[0m\033[1;36m║\033[0m\n"
-        printf "\033[1;36m╚═══════════════════════════════════╝\033[0m\n"
+        printf "\033[1;36m╚══════════════════════════════════════════════════════════════════╝\033[0m\n"
       - task: promptProxyType
 
   promptProxyType:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -97,11 +97,6 @@ tasks:
     internal: true
     cmds:
       - |
-        # printf "Waiting for headscale...\n"
-        # for i in $(seq 10); do
-        #   docker compose exec -T headscale headscale version >/dev/null 2>&1 && break
-        #   sleep 1
-        # done
         KEY=$(docker compose exec -T headscale headscale apikeys create --expiration {{.API_KEY_EXPIRATION}})
         printf "\033[1;37mControl plane API key (enter this in the web UI to log in):\033[0m\n"
         printf "\033[1;32m$KEY\033[0m\n"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -30,6 +30,7 @@ tasks:
         if: 'grep -q "CONTROL_PLANE_TYPE=Ephemeral" .env 2>/dev/null'
       - cmd: docker compose up -d headscale ui
         if: '! grep -q "CONTROL_PLANE_TYPE=Ephemeral" .env 2>/dev/null'
+      - task: generateAuthKey
     deps:
       - configureControlPlane
 
@@ -92,6 +93,18 @@ tasks:
 #################################
 # Internal tasks
 #################################
+  generateAuthKey:
+    internal: true
+    cmds:
+      - |
+        printf "Waiting for headscale...\n"
+        for i in $(seq 10); do
+          docker compose exec -T headscale headscale version >/dev/null 2>&1 && break
+          sleep 1
+        done
+        KEY=$(docker compose exec -T headscale headscale apikeys create --expiration {{.API_KEY_EXPIRATION}})
+        printf "\033[1;37mControl plane API key (enter this in the web UI to log in):\033[0m\n"
+        printf "\033[1;32m$KEY\033[0m\n"
 
   confirmDotEnv:
     cmds:
@@ -128,9 +141,9 @@ tasks:
     if: 'grep -q "CONTROL_PLANE_TYPE=Ephemeral" .env 2>/dev/null'
     cmds:
       - |
-        printf "\033[1;36m╔══════════════════════════════════════════════════════════════════╗\033[0m\n"
+        printf "\033[1;36m╔═══════════════════════════════════╗\033[0m\n"
         printf "\033[1;36m║\033[0m\033[1;37m Choose a domain for your network: \033[0m\033[1;36m║\033[0m\n"
-        printf "\033[1;36m╚══════════════════════════════════════════════════════════════════╝\033[0m\n"
+        printf "\033[1;36m╚═══════════════════════════════════╝\033[0m\n"
       - task: promptProxyType
 
   promptProxyType:

--- a/compose.yml
+++ b/compose.yml
@@ -18,6 +18,12 @@ services:
     tmpfs:
       - /var/run/headscale
     command: serve
+    healthcheck:
+      test: ["CMD", "headscale", "health"]
+      start_period: 5s
+      interval: 5s
+      timeout: 3s
+      retries: 3
 
   ui:
     build: ./control-plane/mesh-ui


### PR DESCRIPTION
Generates the control plane API key after everything's setup, no need to manually run `task apikey`  
Future improvement is to automatically populate this value so users don't have to copy it.  

Also cleaned up the cli UI