### PR TITLE
fix: Delete frps configuration files

### DIFF
--- a/provisioning/internal/docker/container.go
+++ b/provisioning/internal/docker/container.go
@@ -101,6 +101,14 @@ func writeConfig(d state.Deployment) (string, error) {
 }
 
 func (Manager) Stop(slug string) error {
+	hostDataPath := os.Getenv("HOST_DATA_PATH")
+	if hostDataPath == "" {
+		return fmt.Errorf("HOST_DATA_PATH not set")
+	}
+
+	dir := filepath.Join(hostDataPath, slug)
+	os.RemoveAll(dir)
+
 	c, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		return err


### PR DESCRIPTION
Old frp config files were not being removed when a container was removed.  

Ignoring error on deletion as we still want to kill the docker container itself if removing the toml file fails.  I think a separate piece of work in the future will be needed for maintenance to clean up stale deployments etc which can run once a day / week / as often as we need.  