### PR TITLE
Prepare domain provisioning for testing

### DIFF
--- a/.provisioner.env.example
+++ b/.provisioner.env.example
@@ -1,3 +1,0 @@
-PROVISIONER_URL=https://provisioner.tunnel.your-domain.com
-PROVISIONER_API_KEY=random 32 byte api key
-MESH_DOMAIN=your-domain.com

--- a/README.md
+++ b/README.md
@@ -77,22 +77,46 @@ git clone https://github.com/BARGHEST-ngo/mesh.git
 cd MESH
 ```
 
-### 2. Start control plane and get an API key
+### 2. Start control plane
 
 ```
 task build
 task controlPlane
-task apikey
 ```
 
-### 3. Access web UI with API key
+`task controlPlane` walks you through setup interactively and starts all required services. For most users selecting **Ephemeral** with an **Automatic** domain is the recommended route - it requires no server or DNS configuration.
 
+**Choose a deployment type.** An ephemeral control plane runs on your workstation and is accessible over the internet via a secure tunnel. A persistent control plane runs on a dedicated internet-facing server you manage.
+<img src="https://github.com/user-attachments/assets/4633a0e4-95e9-4db9-b85b-606075c0e8c3" />
+
+**Choose a domain.** Selecting Automatic lets MESH provision a public HTTPS address for you. Select Manual if you want to use your own domain.
+
+<img src="https://github.com/user-attachments/assets/5c76c30d-8821-4efa-8f5f-3e4c6db7b932" />
+
+**Confirm configuration.** Review the generated settings before MESH starts.  
+If these settings are incorrect, or if setup was interrupted, delete `.env` and run `task controlPlane` to start again.
 ```
-Local:  https://localhost
-Remote: https://your-domain:8443/login
+CONTROL_PLANE_TYPE=Ephemeral
+PROXY_DOMAIN_TYPE=Automatic
+MESH_SUBDOMAIN=<random 10 character slug>
+FRP_AUTH_TOKEN=<secret token>
+CONTROL_PLANE_URL=https://<slug>.tunnel.meshforensics.app
+LOGIN_URL=https://<slug>.tunnel.meshforensics.app
 ```
 
-The Web UI uses a self-signed certificate by default.
+**Containers start and an API key is generated.** Once all services are healthy, MESH prints a one-time API key to log into the web UI.
+```
+Control plane API key (enter this in the web UI to log in):
+<SECRET API KEY>
+```
+
+### 3. Access the web UI
+
+Navigate to your control plane URL and enter the API key when prompted to log in.
+
+`https://<slug>.tunnel.meshforensics.app`
+
+The web UI is served over HTTPS with a certificate issued automatically by Let's Encrypt.
 
 > [!IMPORTANT]
 > The default ACL allows nodes in each network talk to each other.
@@ -102,6 +126,9 @@ The Web UI uses a self-signed certificate by default.
 
 Your MESH network is now ready to accept nodes.  
 See the documentation for node enrollment and forensic workflows.
+
+### 4. Teardown
+`task down` destroys the MESH network, disconnecting all users, and if you chose an **Ephemeral** deployment with an **Automatic** domain, these and all traces are removed and can no longer be accessed.
 
 ## Architecture summary
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -103,7 +103,7 @@ tasks:
 
   confirmDotEnv:
     cmds:
-      - defer: '{{if .EXIT_CODE}}echo Please manually edit .env or delete it and re-run the task.{{end}}'
+      - defer: '{{if .EXIT_CODE}}rm -f .env && printf "\033[1;33mConfiguration cleared. Run task controlPlane to start again.\033[0m\n"{{end}}'
       - task -t Taskfile.dev.yml promptConfirmDotEnv 2>/dev/null
 
   controlPlaneType:
@@ -136,9 +136,9 @@ tasks:
     if: 'grep -q "CONTROL_PLANE_TYPE=Ephemeral" .env 2>/dev/null'
     cmds:
       - |
-        printf "\033[1;36m╔══════════════════════════════════════════════════════════════════╗\033[0m\n"
+        printf "\033[1;36m╔═══════════════════════════════════╗\033[0m\n"
         printf "\033[1;36m║\033[0m\033[1;37m Choose a domain for your network: \033[0m\033[1;36m║\033[0m\n"
-        printf "\033[1;36m╚══════════════════════════════════════════════════════════════════╝\033[0m\n"
+        printf "\033[1;36m╚═══════════════════════════════════╝\033[0m\n"
       - task: promptProxyType
 
   promptProxyType:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,6 +38,8 @@ tasks:
     cmds:
       - task: controlPlaneType
       - task: proxyType
+      - task: provisionerApiKey
+        if: 'grep -q "PROXY_DOMAIN_TYPE=Automatic" .env 2>/dev/null'
       - task: autoDomain
       - task: manualDomain
       - task: headscaleConfig
@@ -49,7 +51,7 @@ tasks:
     cmds:
       - |
         if grep -q "CONTROL_PLANE_TYPE=Ephemeral" .env 2>/dev/null && [ -n "$MESH_SUBDOMAIN" ]; then
-          if ! curl -sf -X DELETE "$PROVISIONER_URL/deployment/$MESH_SUBDOMAIN" -H "Authorization: Bearer $PROVISIONER_API_KEY"; then
+          if ! curl -sf -X DELETE "https://provisioner.tunnel.meshforensics.app/deployment/$MESH_SUBDOMAIN" -H "Authorization: Bearer $PROVISIONER_API_KEY"; then
             printf "\033[1;31mFailed to delete deployment $MESH_SUBDOMAIN.\nPlease contact support quoting '$MESH_SUBDOMAIN'.\033[0m\n"
           else
             printf "\033[1;32mDeleted deployment $MESH_SUBDOMAIN.\033[0m\n"
@@ -184,15 +186,51 @@ tasks:
     deps:
       - createDotEnv
 
+  provisionerApiKey:
+    internal: true
+    if: '[ -z "$PROVISIONER_API_KEY" ]'
+    cmds:
+      - |
+        printf "\033[1;36m╔════════════════════════════════════════╗\033[0m\n"
+        printf "\033[1;36m║\033[0m\033[1;37m What is your MESH Provisioner API key? \033[0m\033[1;36m║\033[0m\n"
+        printf "\033[1;36m║\033[0m\033[1;37m DO NOT SHARE THIS KEY                  \033[0m\033[1;36m║\033[0m\n"
+        printf "\033[1;36m╚════════════════════════════════════════╝\033[0m\n"
+      - task: promptProvisionerApiKey
+
+  promptProvisionerApiKey:
+    internal: true
+    requires:
+      vars:
+        - PROVISIONER_API_KEY
+    cmds:
+      - cmd: >
+          grep -s PROVISIONER_API_KEY .provisioner.env &&
+          sed -i "s/^PROVISIONER_API_KEY=.*$/PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}/" .provisioner.env ||
+          echo "PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}" >> .provisioner.env
+        platforms: [linux]
+      - cmd: >
+          grep -s PROVISIONER_API_KEY .provisioner.env &&
+          sed -i '' "s/^PROVISIONER_API_KEY=.*$/PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}/" .provisioner.env ||
+          echo "PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}" >> .provisioner.env
+        platforms: [darwin]
+      - cmd: >
+          powershell -Command
+          "if (Select-String -Path '.provisioner.env' -Pattern '^PROVISIONER_API_KEY=' -Quiet) { (Get-Content '.provisioner.env') -replace '^PROVISIONER_API_KEY=.*$', 'PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}' | Set-Content '.provisioner.env' } else { Add-Content '.provisioner.env' 'PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}' }"
+        platforms: [windows]
+    deps:
+      - createProvisionerEnv
+
   autoDomain:
     internal: true
     if: 'grep -q "PROXY_DOMAIN_TYPE=Automatic" .env 2>/dev/null && [ -z "$MESH_SUBDOMAIN" ]'
     cmds:
       - |
-        if [ -z "$PROVISIONER_URL" ] || [ -z "$PROVISIONER_API_KEY" ]; then
-          printf "\033[1;31mMissing provisioner config. Create a '.provisioner.env' file from the provided example.\033[0m\n"
+        [ -f .provisioner.env ] && . ./.provisioner.env
+        if [ -z "$PROVISIONER_API_KEY" ]; then
+          printf "\033[1;31mMissing provisioner API key. Run task controlPlane to set it up.\033[0m\n"
           exit 1
         fi
+        PROVISIONER_URL=https://provisioner.tunnel.meshforensics.app
         if ! RESPONSE=$(curl -sf -X POST "$PROVISIONER_URL/deployment" -H "Authorization: Bearer $PROVISIONER_API_KEY"); then
           printf "\033[1;31mFailed to provision a new deployment.\033[0m\n"
           exit 1
@@ -201,19 +239,18 @@ tasks:
         FRP_SLUG=$(echo "$RESPONSE" | jq -r '.slug')
         FRP_TOKEN=$(echo "$RESPONSE" | jq -r '.token')
         FRP_PORT=$(echo "$RESPONSE" | jq -r '.frps_port')
-        printf "\033[1;32mCreated deployment $FRP_SLUG on port $FRP_PORT\033[0m\n\n"
+        printf "\033[1;32mCreated deployment $FRP_SLUG\n\n"
         sed -e "s|FRP_HOST|$FRP_HOST|g" \
             -e "s|FRP_PORT|$FRP_PORT|g" \
             -e "s|FRP_AUTH_TOKEN|$FRP_TOKEN|g" \
             -e "s|FRP_SLUG|$FRP_SLUG|g" \
-            -e "s|MESH_DOMAIN|$MESH_DOMAIN|g" \
             control-plane/frpc.toml.example > control-plane/frpc.toml
-        sed -e "s|CONTROL_PLANE_URL|https://$FRP_SLUG.tunnel.$MESH_DOMAIN|g" \
+        sed -e "s|CONTROL_PLANE_URL|https://$FRP_SLUG.tunnel.meshforensics.app|g" \
             control-plane/headscale/config.example.yaml > control-plane/headscale/config.yaml
         echo "MESH_SUBDOMAIN=$FRP_SLUG" >> .env
         echo "FRP_AUTH_TOKEN=$FRP_TOKEN" >> .env
-        echo "CONTROL_PLANE_URL=https://$FRP_SLUG.tunnel.$MESH_DOMAIN" >> .env
-        echo "LOGIN_URL=https://$FRP_SLUG.tunnel.$MESH_DOMAIN" >> .env
+        echo "CONTROL_PLANE_URL=https://$FRP_SLUG.tunnel.meshforensics.app" >> .env
+        echo "LOGIN_URL=https://$FRP_SLUG.tunnel.meshforensics.app" >> .env
     deps:
       - createDotEnv
 
@@ -306,3 +343,7 @@ tasks:
   createDotEnv:
     internal: true
     cmd: '[ -f .env ] || (touch .env && chmod 600 .env)'
+
+  createProvisionerEnv:
+    internal: true
+    cmd: '[ -f .provisioner.env ] || (touch .provisioner.env && chmod 600 .provisioner.env)'

--- a/control-plane/frpc.toml.example
+++ b/control-plane/frpc.toml.example
@@ -8,4 +8,4 @@ name = "mesh"
 type = "http"
 localIP = "ui"
 localPort = 8080
-customDomains = ["FRP_SLUG.tunnel.MESH_DOMAIN"]
+customDomains = ["FRP_SLUG.tunnel.meshforensics.app"]

--- a/provisioning/cmd/server/main.go
+++ b/provisioning/cmd/server/main.go
@@ -56,11 +56,6 @@ func main() {
 		log.Fatal("FRPS_IMAGE must be set")
 	}
 
-	meshDomain := os.Getenv("MESH_DOMAIN")
-	if meshDomain == "" {
-		log.Fatal("MESH_DOMAIN must be set")
-	}
-
 	if err := docker.PullImage(frpsImage); err != nil {
 		log.Fatalf("failed to pull frps image: %v", err)
 	}
@@ -72,7 +67,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:         ":8080",
-		Handler:      api.NewRouter(apiKey, registry, frpsImage, meshDomain),
+		Handler:      api.NewRouter(apiKey, registry, frpsImage),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}

--- a/provisioning/compose.yml
+++ b/provisioning/compose.yml
@@ -16,7 +16,7 @@ services:
       - mesh-proxy
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.provisioner.rule=Host(`provisioner.tunnel.${MESH_DOMAIN}`)"
+      - "traefik.http.routers.provisioner.rule=Host(`provisioner.tunnel.meshforensics.app`)"
       - "traefik.http.routers.provisioner.tls=true"
       - "traefik.http.routers.provisioner.tls.certresolver=letsencrypt"
       - "traefik.http.services.provisioner.loadbalancer.server.port=8080"

--- a/provisioning/internal/api/deployment.go
+++ b/provisioning/internal/api/deployment.go
@@ -70,6 +70,9 @@ func (h *handler) handleDeleteDeployment(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	h.registry.Release(slug)
+	if err := h.registry.Release(slug); err != nil {
+		http.Error(w, err.Error(), http.StatusNotFound)
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 }

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -1,22 +1,39 @@
 package api_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/api"
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
 )
 
-const testAPIKey = "test-key"
+const (
+	testAPIKey = "test-key"
+	minPort    = 7001
+	maxPort    = 7010
+)
 
 type mockContainerService struct{}
 
 func (mockContainerService) Start(state.Deployment) error { return nil }
 func (mockContainerService) Stop(string) error            { return nil }
+
+type failOnceMock struct{ calls int }
+
+func (m *failOnceMock) Start(state.Deployment) error {
+	m.calls++
+	if m.calls == 1 {
+		return fmt.Errorf("simulated start failure")
+	}
+	return nil
+}
+func (m *failOnceMock) Stop(string) error { return nil }
 
 func newTestRouter(t *testing.T) http.Handler {
 	t.Helper()
@@ -25,6 +42,31 @@ func newTestRouter(t *testing.T) http.Handler {
 		t.Fatal(err)
 	}
 	return api.NewRouter(testAPIKey, reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
+}
+
+func validTestDeployment(t *testing.T) api.DeploymentResponse {
+	req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", testAPIKey))
+	w := httptest.NewRecorder()
+	newTestRouter(t).ServeHTTP(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("failed to create deployment")
+	}
+	var resp api.DeploymentResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	return resp
+}
+
+func TestHealth(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	newTestRouter(t).ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("cannot reach health endpoint")
+	}
 }
 
 func TestPostDeployment(t *testing.T) {
@@ -54,6 +96,29 @@ func TestPostDeployment(t *testing.T) {
 	}
 }
 
+func TestPostDeploymentStructure(t *testing.T) {
+	cases := []struct {
+		name string
+		test func(api.DeploymentResponse) bool
+	}{
+		{"valid slug", func(d api.DeploymentResponse) bool {
+			return len(d.Slug) == 10
+		}},
+		{"valid port", func(d api.DeploymentResponse) bool {
+			return d.FrpsPort >= minPort && d.FrpsPort <= maxPort
+		}},
+	}
+
+	d := validTestDeployment(t)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if ok := tc.test(d); !ok {
+				t.Errorf("%s failed", tc.name)
+			}
+		})
+	}
+}
+
 func TestPostDeploymentPortExhaustion(t *testing.T) {
 	reg, err := state.New(filepath.Join(t.TempDir(), "state.json"), 7001, 7001)
 	if err != nil {
@@ -75,5 +140,142 @@ func TestPostDeploymentPortExhaustion(t *testing.T) {
 
 	if code := makeRequest(); code != http.StatusInternalServerError {
 		t.Errorf("second request expected %d, got %d", http.StatusInternalServerError, code)
+	}
+}
+
+func TestStartFailureRollsBackPort(t *testing.T) {
+	reg, err := state.New(filepath.Join(t.TempDir(), "state.json"), 7001, 7001)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mock := &failOnceMock{}
+	router := api.NewRouter(testAPIKey, reg, "some_frps_image", api.WithContainerService(mock))
+
+	post := func() int {
+		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", testAPIKey))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := post(); code != http.StatusInternalServerError {
+		t.Fatalf("expected start failure to return 500, got %d", code)
+	}
+	if code := post(); code != http.StatusCreated {
+		t.Errorf("expected port to be freed after rollback, got %d", code)
+	}
+}
+
+func TestConcurrentDeployments(t *testing.T) {
+	var mu sync.Mutex
+	var deployments []api.DeploymentResponse
+	var codes []int
+
+	reg, err := state.New(filepath.Join(t.TempDir(), "state.json"), 7001, 7010)
+	if err != nil {
+		t.Fatalf("failed to create registry")
+	}
+	router := api.NewRouter(testAPIKey, reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", testAPIKey))
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			mu.Lock()
+			codes = append(codes, w.Code)
+			if w.Code == http.StatusCreated {
+				var created api.DeploymentResponse
+				json.NewDecoder(w.Body).Decode(&created)
+				deployments = append(deployments, created)
+			}
+			mu.Unlock()
+		}()
+	}
+	wg.Wait()
+
+	for _, code := range codes {
+		if code != http.StatusCreated {
+			t.Fatalf("expected %d, got %d", http.StatusCreated, code)
+		}
+	}
+
+	cases := []struct {
+		name  string
+		check func([]api.DeploymentResponse) error
+	}{
+		{
+			"duplicate-ports",
+			func(results []api.DeploymentResponse) error {
+				seen := make(map[int]struct{})
+				for _, d := range results {
+					if _, exists := seen[d.FrpsPort]; exists {
+						return fmt.Errorf("duplicate port allocated: %d", d.FrpsPort)
+					}
+					seen[d.FrpsPort] = struct{}{}
+				}
+				return nil
+			},
+		},
+		{
+			"duplicate-slugs",
+			func(results []api.DeploymentResponse) error {
+				seen := make(map[string]struct{})
+				for _, d := range results {
+					if _, exists := seen[d.Slug]; exists {
+						return fmt.Errorf("duplicate slug allocated: %s", d.Slug)
+					}
+					seen[d.Slug] = struct{}{}
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.check(deployments); err != nil {
+				t.Errorf("failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestDeleteDeployment(t *testing.T) {
+	router := newTestRouter(t)
+	req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", testAPIKey))
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatal("failed to create deployment")
+	}
+	var created api.DeploymentResponse
+	json.NewDecoder(w.Body).Decode(&created)
+
+	cases := []struct {
+		name     string
+		slug     string
+		expected int
+	}{
+		{"ok", created.Slug, http.StatusOK},
+		{"slug does not exist", "wrong-slug", http.StatusNotFound},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/deployment/%s", tc.slug), nil)
+			req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", testAPIKey))
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			if w.Code != tc.expected {
+				t.Errorf("expected %d, got %d", tc.expected, w.Code)
+			}
+		})
 	}
 }

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -44,22 +44,6 @@ func newTestRouter(t *testing.T) http.Handler {
 	return api.NewRouter(testAPIKey, reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
 }
 
-func validTestDeployment(t *testing.T) api.DeploymentResponse {
-	req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", testAPIKey))
-	w := httptest.NewRecorder()
-	newTestRouter(t).ServeHTTP(w, req)
-
-	if w.Code != http.StatusCreated {
-		t.Fatalf("failed to create deployment")
-	}
-	var resp api.DeploymentResponse
-	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
-		t.Fatalf("failed to decode response: %v", err)
-	}
-	return resp
-}
-
 func TestHealth(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
@@ -97,25 +81,25 @@ func TestPostDeployment(t *testing.T) {
 }
 
 func TestPostDeploymentStructure(t *testing.T) {
-	cases := []struct {
-		name string
-		test func(api.DeploymentResponse) bool
-	}{
-		{"valid slug", func(d api.DeploymentResponse) bool {
-			return len(d.Slug) == 10
-		}},
-		{"valid port", func(d api.DeploymentResponse) bool {
-			return d.FrpsPort >= minPort && d.FrpsPort <= maxPort
-		}},
+	req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", testAPIKey))
+	w := httptest.NewRecorder()
+	newTestRouter(t).ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("failed to create deployment")
 	}
 
-	d := validTestDeployment(t)
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if ok := tc.test(d); !ok {
-				t.Errorf("%s failed", tc.name)
-			}
-		})
+	var d api.DeploymentResponse
+	if err := json.NewDecoder(w.Body).Decode(&d); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if len(d.Slug) != 10 {
+		t.Errorf("expected valid slug")
+	}
+
+	if d.FrpsPort < minPort || d.FrpsPort > maxPort {
+		t.Errorf("expected valid port")
 	}
 }
 

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -24,7 +24,7 @@ func newTestRouter(t *testing.T) http.Handler {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return api.NewRouter(testAPIKey, reg, "some_frps_image", "your-domain", api.WithContainerService(mockContainerService{}))
+	return api.NewRouter(testAPIKey, reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
 }
 
 func TestPostDeployment(t *testing.T) {
@@ -59,7 +59,7 @@ func TestPostDeploymentPortExhaustion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	router := api.NewRouter(testAPIKey, reg, "some_frps_image", "your-domain", api.WithContainerService(mockContainerService{}))
+	router := api.NewRouter(testAPIKey, reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
 
 	makeRequest := func() int {
 		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)

--- a/provisioning/internal/api/handler.go
+++ b/provisioning/internal/api/handler.go
@@ -25,13 +25,12 @@ type ContainerService interface {
 	Stop(slug string) error
 }
 
-func NewRouter(apiKey string, registry *state.Registry, frpsImage, meshDomain string, opts ...Option) http.Handler {
+func NewRouter(apiKey string, registry *state.Registry, frpsImage string, opts ...Option) http.Handler {
 	keyHash := sha256.Sum256([]byte(apiKey))
 	h := &handler{
 		registry: registry,
 		service: docker.Manager{
-			FrpsImage:  frpsImage,
-			MeshDomain: meshDomain,
+			FrpsImage: frpsImage,
 		},
 	}
 	for _, opt := range opts {

--- a/provisioning/internal/docker/container.go
+++ b/provisioning/internal/docker/container.go
@@ -14,9 +14,10 @@ import (
 	"github.com/docker/go-connections/nat"
 )
 
+const meshDomain = "meshforensics.app"
+
 type Manager struct {
-	FrpsImage  string
-	MeshDomain string
+	FrpsImage string
 }
 
 func PullImage(imageName string) error {
@@ -53,11 +54,11 @@ func (m Manager) Start(d state.Deployment) error {
 			Image: m.FrpsImage,
 			Labels: map[string]string{
 				"traefik.enable": "true",
-				fmt.Sprintf("traefik.http.routers.%s.rule", d.Slug):                      fmt.Sprintf("Host(`%s.tunnel.%s`)", d.Slug, m.MeshDomain),
+				fmt.Sprintf("traefik.http.routers.%s.rule", d.Slug):                      fmt.Sprintf("Host(`%s.tunnel.%s`)", d.Slug, meshDomain),
 				fmt.Sprintf("traefik.http.routers.%s.tls", d.Slug):                       "true",
 				fmt.Sprintf("traefik.http.routers.%s.tls.certresolver", d.Slug):          "letsencrypt",
-				fmt.Sprintf("traefik.http.routers.%s.tls.domains[0].main", d.Slug):       "tunnel." + m.MeshDomain,
-				fmt.Sprintf("traefik.http.routers.%s.tls.domains[0].sans", d.Slug):       "*.tunnel." + m.MeshDomain,
+				fmt.Sprintf("traefik.http.routers.%s.tls.domains[0].main", d.Slug):       "tunnel." + meshDomain,
+				fmt.Sprintf("traefik.http.routers.%s.tls.domains[0].sans", d.Slug):       "*.tunnel." + meshDomain,
 				fmt.Sprintf("traefik.http.services.%s.loadbalancer.server.port", d.Slug): "8080",
 				"traefik.docker.network": "mesh-proxy",
 			},

--- a/provisioning/provisioner.env.example
+++ b/provisioning/provisioner.env.example
@@ -2,7 +2,6 @@ FRPS_IMAGE=snowdreamtech/frps:latest
 FRPS_PORT_MIN=7000
 FRPS_PORT_MAX=7100
 PROVISIONER_API_KEY=random 32 byte api key
-MESH_DOMAIN=your-domain.com
 TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL=porkbun account email
 PORKBUN_API_KEY=generated in porkbun account settings
 PORKBUN_SECRET_API_KEY=generated in porkbun account settings


### PR DESCRIPTION
## Summary
Prep for external testing:
- Remove need to create a `.provisioner.env` file. Domain variables within are now hardcoded, and user is prompted for their API key during setup.
- Updated README instructions for ephemeral deployments with automatic domains
- Generally cleaned up UX whilst going through the interactive control plane tasks
- Added more test cases covering failure states and concurrent deployments