### PR TITLE
KeyStore for API Keys

### DIFF
--- a/provisioning/cmd/server/main.go
+++ b/provisioning/cmd/server/main.go
@@ -19,14 +19,6 @@ import (
 // This is an intentionally light-weight and basic HTTP server
 // Don't want to over-engineer at this stage, just prove it works
 func main() {
-	// PROVISIONER_API_KEY during early dev will be a single shared secret
-	// Internal use only during development
-	// Moving to per-customer keys as we get closer to prod
-	apiKey := os.Getenv("PROVISIONER_API_KEY")
-	if apiKey == "" {
-		log.Fatal("PROVISIONER_API_KEY must be set")
-	}
-
 	portMin := os.Getenv("FRPS_PORT_MIN")
 	if portMin == "" {
 		log.Fatal("FRPS_PORT_MIN must be set")
@@ -65,9 +57,14 @@ func main() {
 		log.Fatal("failed to initialise port registry")
 	}
 
+	keyStore, err := state.NewKeyStore(filepath.Join(dataPath, "keys.json"))
+	if err != nil {
+		log.Fatal("failed to initialise key store")
+	}
+
 	srv := &http.Server{
 		Addr:         ":8080",
-		Handler:      api.NewRouter(apiKey, registry, frpsImage),
+		Handler:      api.NewRouter(keyStore, registry, frpsImage),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}

--- a/provisioning/cmd/server/main.go
+++ b/provisioning/cmd/server/main.go
@@ -64,7 +64,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:         ":8080",
-		Handler:      api.NewRouter(keyStore, registry, frpsImage),
+		Handler:      api.NewRouter(keyStore, registry, docker.Manager{FrpsImage: frpsImage}),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}

--- a/provisioning/internal/api/auth_test.go
+++ b/provisioning/internal/api/auth_test.go
@@ -1,21 +1,20 @@
-package api
+package api_test
 
 import (
-	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/BARGHEST-ngo/MESH/provisioning/internal/api"
 )
 
 func TestAuthRequest(t *testing.T) {
-	keyHash := sha256.Sum256([]byte("test-key"))
-
 	dummy := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := authRequest(keyHash, dummy)
+	handler := api.AuthRequest(newTestKeyStore(t), dummy)
 
 	cases := []struct {
 		name     string

--- a/provisioning/internal/api/auth_test.go
+++ b/provisioning/internal/api/auth_test.go
@@ -1,12 +1,10 @@
-package api_test
+package api
 
 import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/BARGHEST-ngo/MESH/provisioning/internal/api"
 )
 
 func TestAuthRequest(t *testing.T) {
@@ -14,7 +12,7 @@ func TestAuthRequest(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	handler := api.AuthRequest(newTestKeyStore(t), dummy)
+	handler := authRequest(newTestKeyStore(t), dummy)
 
 	cases := []struct {
 		name     string

--- a/provisioning/internal/api/deployment.go
+++ b/provisioning/internal/api/deployment.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+
+	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
 )
 
 // Provision a new frp container
@@ -24,7 +26,13 @@ func (h *handler) handlePostDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	d, err := h.registry.AllocatePort(slug, token)
+	key, ok := r.Context().Value(apiKeyContextKey).(state.APIKey)
+	if !ok {
+		http.Error(w, "", http.StatusBadRequest)
+		return
+	}
+
+	d, err := h.registry.AllocatePort(slug, token, key.ID, key.MaxConcurrent)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to allocate port: %v", err), http.StatusInternalServerError)
 		return

--- a/provisioning/internal/api/deployment.go
+++ b/provisioning/internal/api/deployment.go
@@ -32,7 +32,7 @@ func (h *handler) handlePostDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	d, err := h.registry.AllocatePort(slug, token, key.ID, key.MaxConcurrent)
+	d, err := h.registry.AllocatePort(slug, token, key.OwnerID, key.MaxConcurrent)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to allocate port: %v", err), http.StatusInternalServerError)
 		return

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -285,8 +285,6 @@ func TestConcurrentDeployments(t *testing.T) {
 }
 
 func TestApiKeyStates(t *testing.T) {
-	//keyHash := sha256.Sum256([]byte(testAPIKey))
-
 	post := func(router http.Handler) int {
 		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
 		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", testAPIKey))

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/api"
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
+	"github.com/google/uuid"
 )
 
 const (
@@ -44,8 +45,9 @@ func defaultTestKey() state.APIKey {
 	created := time.Now()
 	expires := created.Add(time.Hour)
 	return state.APIKey{
-		ID:            "test-owner",
-		Label:         "test",
+		ID:            uuid.NewString(),
+		OwnerID:       "tests",
+		Label:         "automated-testing",
 		HashHex:       hex.EncodeToString(hash[:]),
 		MaxConcurrent: 0,
 		Revoked:       false,

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -1,13 +1,17 @@
 package api_test
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/api"
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
@@ -41,7 +45,38 @@ func newTestRouter(t *testing.T) http.Handler {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return api.NewRouter(testAPIKey, reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
+	return api.NewRouter(newTestKeyStore(t), reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
+}
+
+func newTestKeyStore(t *testing.T) *state.KeyStore {
+	t.Helper()
+	hash := sha256.Sum256([]byte(testAPIKey))
+	created := time.Now()
+	expires := created.Add(time.Hour)
+	key := state.APIKey{
+		ID:            "test-owner",
+		Label:         "test",
+		HashHex:       hex.EncodeToString(hash[:]),
+		MaxConcurrent: 0,
+		Revoked:       false,
+		CreatedAt:     created,
+		ExpiresAt:     &expires,
+	}
+	data, err := json.Marshal(struct {
+		Keys []state.APIKey `json:"keys"`
+	}{Keys: []state.APIKey{key}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "keys.json")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	ks, err := state.NewKeyStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ks
 }
 
 func TestHealth(t *testing.T) {
@@ -108,7 +143,7 @@ func TestPostDeploymentPortExhaustion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	router := api.NewRouter(testAPIKey, reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
+	router := api.NewRouter(newTestKeyStore(t), reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
 
 	makeRequest := func() int {
 		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
@@ -133,7 +168,7 @@ func TestStartFailureRollsBackPort(t *testing.T) {
 		t.Fatal(err)
 	}
 	mock := &failOnceMock{}
-	router := api.NewRouter(testAPIKey, reg, "some_frps_image", api.WithContainerService(mock))
+	router := api.NewRouter(newTestKeyStore(t), reg, "some_frps_image", api.WithContainerService(mock))
 
 	post := func() int {
 		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
@@ -160,7 +195,7 @@ func TestConcurrentDeployments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create registry")
 	}
-	router := api.NewRouter(testAPIKey, reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
+	router := api.NewRouter(newTestKeyStore(t), reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
 
 	var wg sync.WaitGroup
 	for range 10 {

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -42,7 +42,6 @@ func (m *failOnceMock) Stop(string) error { return nil }
 func defaultTestKey() state.APIKey {
 	hash := sha256.Sum256([]byte(testAPIKey))
 	created := time.Now()
-	expires := created.Add(time.Hour)
 	return state.APIKey{
 		ID:            uuid.NewString(),
 		OwnerID:       "tests",
@@ -51,11 +50,11 @@ func defaultTestKey() state.APIKey {
 		MaxConcurrent: 0,
 		Revoked:       false,
 		CreatedAt:     created,
-		ExpiresAt:     &expires,
+		ExpiresAt:     nil,
 	}
 }
 
-func newTestRouterWIthKey(t *testing.T, key state.APIKey) http.Handler {
+func newTestRouterWithKey(t *testing.T, key state.APIKey) http.Handler {
 	t.Helper()
 	reg, err := state.New(filepath.Join(t.TempDir(), "state.json"), 7001, 7010)
 	if err != nil {
@@ -297,7 +296,7 @@ func TestApiKeyStates(t *testing.T) {
 		key := defaultTestKey()
 		key.ExpiresAt = &expires
 
-		if code := post(newTestRouterWIthKey(t, key)); code != http.StatusUnauthorized {
+		if code := post(newTestRouterWithKey(t, key)); code != http.StatusUnauthorized {
 			t.Errorf("expected %d, got %d", http.StatusUnauthorized, code)
 		}
 	})
@@ -306,7 +305,7 @@ func TestApiKeyStates(t *testing.T) {
 		key := defaultTestKey()
 		key.Revoked = true
 
-		if code := post(newTestRouterWIthKey(t, key)); code != http.StatusUnauthorized {
+		if code := post(newTestRouterWithKey(t, key)); code != http.StatusUnauthorized {
 			t.Errorf("expected %d, got %d", http.StatusUnauthorized, code)
 		}
 	})

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -39,6 +39,30 @@ func (m *failOnceMock) Start(state.Deployment) error {
 }
 func (m *failOnceMock) Stop(string) error { return nil }
 
+func defaultTestKey() state.APIKey {
+	hash := sha256.Sum256([]byte(testAPIKey))
+	created := time.Now()
+	expires := created.Add(time.Hour)
+	return state.APIKey{
+		ID:            "test-owner",
+		Label:         "test",
+		HashHex:       hex.EncodeToString(hash[:]),
+		MaxConcurrent: 0,
+		Revoked:       false,
+		CreatedAt:     created,
+		ExpiresAt:     &expires,
+	}
+}
+
+func newTestRouterWIthKey(t *testing.T, key state.APIKey) http.Handler {
+	t.Helper()
+	reg, err := state.New(filepath.Join(t.TempDir(), "state.json"), 7001, 7010)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return api.NewRouter(newTestKeyStoreWithKey(t, key), reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
+}
+
 func newTestRouter(t *testing.T) http.Handler {
 	t.Helper()
 	reg, err := state.New(filepath.Join(t.TempDir(), "state.json"), 7001, 7010)
@@ -48,20 +72,8 @@ func newTestRouter(t *testing.T) http.Handler {
 	return api.NewRouter(newTestKeyStore(t), reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
 }
 
-func newTestKeyStore(t *testing.T) *state.KeyStore {
+func newTestKeyStoreWithKey(t *testing.T, key state.APIKey) *state.KeyStore {
 	t.Helper()
-	hash := sha256.Sum256([]byte(testAPIKey))
-	created := time.Now()
-	expires := created.Add(time.Hour)
-	key := state.APIKey{
-		ID:            "test-owner",
-		Label:         "test",
-		HashHex:       hex.EncodeToString(hash[:]),
-		MaxConcurrent: 0,
-		Revoked:       false,
-		CreatedAt:     created,
-		ExpiresAt:     &expires,
-	}
 	data, err := json.Marshal(struct {
 		Keys []state.APIKey `json:"keys"`
 	}{Keys: []state.APIKey{key}})
@@ -77,6 +89,11 @@ func newTestKeyStore(t *testing.T) *state.KeyStore {
 		t.Fatal(err)
 	}
 	return ks
+}
+
+func newTestKeyStore(t *testing.T) *state.KeyStore {
+	t.Helper()
+	return newTestKeyStoreWithKey(t, defaultTestKey())
 }
 
 func TestHealth(t *testing.T) {
@@ -263,6 +280,57 @@ func TestConcurrentDeployments(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApiKeyStates(t *testing.T) {
+	//keyHash := sha256.Sum256([]byte(testAPIKey))
+
+	post := func(router http.Handler) int {
+		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", testAPIKey))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	t.Run("expired-key", func(t *testing.T) {
+		expires := time.Now().Add(-time.Hour)
+		key := defaultTestKey()
+		key.ExpiresAt = &expires
+
+		if code := post(newTestRouterWIthKey(t, key)); code != http.StatusUnauthorized {
+			t.Errorf("expected %d, got %d", http.StatusUnauthorized, code)
+		}
+	})
+
+	t.Run("revoked-key", func(t *testing.T) {
+		key := defaultTestKey()
+		key.Revoked = true
+
+		if code := post(newTestRouterWIthKey(t, key)); code != http.StatusUnauthorized {
+			t.Errorf("expected %d, got %d", http.StatusUnauthorized, code)
+		}
+	})
+
+	t.Run("over-max-concurrent-deploys", func(t *testing.T) {
+		key := defaultTestKey()
+		key.MaxConcurrent = 2
+		reg, err := state.New(filepath.Join(t.TempDir(), "state.json"), 7001, 7010)
+		if err != nil {
+			t.Fatal(err)
+		}
+		router := api.NewRouter(newTestKeyStoreWithKey(t, key), reg, "some-frps-image", api.WithContainerService(mockContainerService{}))
+		// 2 valid deployments, fail on the 3rd
+		if code := post(router); code != http.StatusCreated {
+			t.Errorf("expected %d, got %d", http.StatusCreated, code)
+		}
+		if code := post(router); code != http.StatusCreated {
+			t.Errorf("expected %d, got %d", http.StatusCreated, code)
+		}
+		if code := post(router); code != http.StatusInternalServerError {
+			t.Errorf("expected %d, got %d", http.StatusInternalServerError, code)
+		}
+	})
 }
 
 func TestDeleteDeployment(t *testing.T) {

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -1,4 +1,4 @@
-package api_test
+package api
 
 import (
 	"crypto/sha256"
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/BARGHEST-ngo/MESH/provisioning/internal/api"
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
 	"github.com/google/uuid"
 )
@@ -62,7 +61,7 @@ func newTestRouterWIthKey(t *testing.T, key state.APIKey) http.Handler {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return api.NewRouter(newTestKeyStoreWithKey(t, key), reg, mockContainerService{})
+	return NewRouter(newTestKeyStoreWithKey(t, key), reg, mockContainerService{})
 }
 
 func newTestRouter(t *testing.T) http.Handler {
@@ -71,7 +70,7 @@ func newTestRouter(t *testing.T) http.Handler {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return api.NewRouter(newTestKeyStore(t), reg, mockContainerService{})
+	return NewRouter(newTestKeyStore(t), reg, mockContainerService{})
 }
 
 func newTestKeyStoreWithKey(t *testing.T, key state.APIKey) *state.KeyStore {
@@ -143,7 +142,7 @@ func TestPostDeploymentStructure(t *testing.T) {
 		t.Fatalf("failed to create deployment")
 	}
 
-	var d api.DeploymentResponse
+	var d DeploymentResponse
 	if err := json.NewDecoder(w.Body).Decode(&d); err != nil {
 		t.Fatalf("failed to decode response: %v", err)
 	}
@@ -162,7 +161,7 @@ func TestPostDeploymentPortExhaustion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	router := api.NewRouter(newTestKeyStore(t), reg, mockContainerService{})
+	router := NewRouter(newTestKeyStore(t), reg, mockContainerService{})
 
 	makeRequest := func() int {
 		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
@@ -187,7 +186,7 @@ func TestStartFailureRollsBackPort(t *testing.T) {
 		t.Fatal(err)
 	}
 	mock := &failOnceMock{}
-	router := api.NewRouter(newTestKeyStore(t), reg, mock)
+	router := NewRouter(newTestKeyStore(t), reg, mock)
 
 	post := func() int {
 		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
@@ -207,14 +206,14 @@ func TestStartFailureRollsBackPort(t *testing.T) {
 
 func TestConcurrentDeployments(t *testing.T) {
 	var mu sync.Mutex
-	var deployments []api.DeploymentResponse
+	var deployments []DeploymentResponse
 	var codes []int
 
 	reg, err := state.New(filepath.Join(t.TempDir(), "state.json"), 7001, 7010)
 	if err != nil {
 		t.Fatalf("failed to create registry")
 	}
-	router := api.NewRouter(newTestKeyStore(t), reg, mockContainerService{})
+	router := NewRouter(newTestKeyStore(t), reg, mockContainerService{})
 
 	var wg sync.WaitGroup
 	for range 10 {
@@ -228,7 +227,7 @@ func TestConcurrentDeployments(t *testing.T) {
 			mu.Lock()
 			codes = append(codes, w.Code)
 			if w.Code == http.StatusCreated {
-				var created api.DeploymentResponse
+				var created DeploymentResponse
 				json.NewDecoder(w.Body).Decode(&created)
 				deployments = append(deployments, created)
 			}
@@ -245,11 +244,11 @@ func TestConcurrentDeployments(t *testing.T) {
 
 	cases := []struct {
 		name  string
-		check func([]api.DeploymentResponse) error
+		check func([]DeploymentResponse) error
 	}{
 		{
 			"duplicate-ports",
-			func(results []api.DeploymentResponse) error {
+			func(results []DeploymentResponse) error {
 				seen := make(map[int]struct{})
 				for _, d := range results {
 					if _, exists := seen[d.FrpsPort]; exists {
@@ -262,7 +261,7 @@ func TestConcurrentDeployments(t *testing.T) {
 		},
 		{
 			"duplicate-slugs",
-			func(results []api.DeploymentResponse) error {
+			func(results []DeploymentResponse) error {
 				seen := make(map[string]struct{})
 				for _, d := range results {
 					if _, exists := seen[d.Slug]; exists {
@@ -319,7 +318,7 @@ func TestApiKeyStates(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		router := api.NewRouter(newTestKeyStoreWithKey(t, key), reg, mockContainerService{})
+		router := NewRouter(newTestKeyStoreWithKey(t, key), reg, mockContainerService{})
 		// 2 valid deployments, fail on the 3rd
 		if code := post(router); code != http.StatusCreated {
 			t.Errorf("expected %d, got %d", http.StatusCreated, code)
@@ -342,7 +341,7 @@ func TestDeleteDeployment(t *testing.T) {
 	if w.Code != http.StatusCreated {
 		t.Fatal("failed to create deployment")
 	}
-	var created api.DeploymentResponse
+	var created DeploymentResponse
 	json.NewDecoder(w.Body).Decode(&created)
 
 	cases := []struct {

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -60,7 +60,7 @@ func newTestRouterWIthKey(t *testing.T, key state.APIKey) http.Handler {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return api.NewRouter(newTestKeyStoreWithKey(t, key), reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
+	return api.NewRouter(newTestKeyStoreWithKey(t, key), reg, mockContainerService{})
 }
 
 func newTestRouter(t *testing.T) http.Handler {
@@ -69,7 +69,7 @@ func newTestRouter(t *testing.T) http.Handler {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return api.NewRouter(newTestKeyStore(t), reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
+	return api.NewRouter(newTestKeyStore(t), reg, mockContainerService{})
 }
 
 func newTestKeyStoreWithKey(t *testing.T, key state.APIKey) *state.KeyStore {
@@ -160,7 +160,7 @@ func TestPostDeploymentPortExhaustion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	router := api.NewRouter(newTestKeyStore(t), reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
+	router := api.NewRouter(newTestKeyStore(t), reg, mockContainerService{})
 
 	makeRequest := func() int {
 		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
@@ -185,7 +185,7 @@ func TestStartFailureRollsBackPort(t *testing.T) {
 		t.Fatal(err)
 	}
 	mock := &failOnceMock{}
-	router := api.NewRouter(newTestKeyStore(t), reg, "some_frps_image", api.WithContainerService(mock))
+	router := api.NewRouter(newTestKeyStore(t), reg, mock)
 
 	post := func() int {
 		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
@@ -212,7 +212,7 @@ func TestConcurrentDeployments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create registry")
 	}
-	router := api.NewRouter(newTestKeyStore(t), reg, "some_frps_image", api.WithContainerService(mockContainerService{}))
+	router := api.NewRouter(newTestKeyStore(t), reg, mockContainerService{})
 
 	var wg sync.WaitGroup
 	for range 10 {
@@ -319,7 +319,7 @@ func TestApiKeyStates(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		router := api.NewRouter(newTestKeyStoreWithKey(t, key), reg, "some-frps-image", api.WithContainerService(mockContainerService{}))
+		router := api.NewRouter(newTestKeyStoreWithKey(t, key), reg, mockContainerService{})
 		// 2 valid deployments, fail on the 3rd
 		if code := post(router); code != http.StatusCreated {
 			t.Errorf("expected %d, got %d", http.StatusCreated, code)

--- a/provisioning/internal/api/export_test.go
+++ b/provisioning/internal/api/export_test.go
@@ -1,0 +1,4 @@
+package api
+
+// authRequest is not exported, expose it for tests
+var AuthRequest = authRequest

--- a/provisioning/internal/api/export_test.go
+++ b/provisioning/internal/api/export_test.go
@@ -1,4 +1,0 @@
-package api
-
-// authRequest is not exported, expose it for tests
-var AuthRequest = authRequest

--- a/provisioning/internal/api/handler.go
+++ b/provisioning/internal/api/handler.go
@@ -21,7 +21,7 @@ type ContainerService interface {
 
 type contextKey string
 
-const apiKeyContextKey contextKey = "ownerID"
+const apiKeyContextKey contextKey = "apikey"
 
 func NewRouter(keys *state.KeyStore, registry *state.Registry, containerSvc ContainerService) http.Handler {
 	h := &handler{

--- a/provisioning/internal/api/handler.go
+++ b/provisioning/internal/api/handler.go
@@ -1,8 +1,9 @@
 package api
 
 import (
+	"context"
 	"crypto/sha256"
-	"crypto/subtle"
+	"fmt"
 	"net/http"
 
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/docker"
@@ -25,8 +26,11 @@ type ContainerService interface {
 	Stop(slug string) error
 }
 
-func NewRouter(apiKey string, registry *state.Registry, frpsImage string, opts ...Option) http.Handler {
-	keyHash := sha256.Sum256([]byte(apiKey))
+type contextKey string
+
+const apiKeyContextKey contextKey = "ownerID"
+
+func NewRouter(keys *state.KeyStore, registry *state.Registry, frpsImage string, opts ...Option) http.Handler {
 	h := &handler{
 		registry: registry,
 		service: docker.Manager{
@@ -41,28 +45,39 @@ func NewRouter(apiKey string, registry *state.Registry, frpsImage string, opts .
 	mux.HandleFunc("POST /deployment", h.handlePostDeployment)
 	mux.HandleFunc("DELETE /deployment/{slug}", h.handleDeleteDeployment)
 
-	return authRequest(keyHash, mux)
+	return authRequest(keys, mux)
 }
 
-func authRequest(keyHash [32]byte, next http.Handler) http.Handler {
+func authRequest(keys *state.KeyStore, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/health" {
 			next.ServeHTTP(w, r)
 			return
 		}
 
-		bearer := r.Header.Get("Authorization")
-		if len(bearer) < 8 || bearer[:7] != "Bearer " {
+		incoming, err := getAuthToken(r)
+		if err != nil {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
 
-		incoming := sha256.Sum256([]byte(bearer[7:]))
-		if subtle.ConstantTimeCompare(incoming[:], keyHash[:]) != 1 {
+		key, ok := keys.Lookup(incoming)
+		if !ok {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
 
-		next.ServeHTTP(w, r)
+		ctx := context.WithValue(r.Context(), apiKeyContextKey, key)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+func getAuthToken(r *http.Request) ([32]byte, error) {
+	bearer := r.Header.Get("Authorization")
+	if len(bearer) < 8 || bearer[:7] != "Bearer " {
+		return [32]byte{}, fmt.Errorf("invalid auth token")
+	}
+
+	token := sha256.Sum256([]byte(bearer[7:]))
+	return token, nil
 }

--- a/provisioning/internal/api/handler.go
+++ b/provisioning/internal/api/handler.go
@@ -6,19 +6,12 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/BARGHEST-ngo/MESH/provisioning/internal/docker"
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
 )
 
 type handler struct {
 	registry *state.Registry
 	service  ContainerService
-}
-
-type Option func(*handler)
-
-func WithContainerService(svc ContainerService) Option {
-	return func(h *handler) { h.service = svc }
 }
 
 type ContainerService interface {
@@ -30,16 +23,12 @@ type contextKey string
 
 const apiKeyContextKey contextKey = "ownerID"
 
-func NewRouter(keys *state.KeyStore, registry *state.Registry, frpsImage string, opts ...Option) http.Handler {
+func NewRouter(keys *state.KeyStore, registry *state.Registry, containerSvc ContainerService) http.Handler {
 	h := &handler{
 		registry: registry,
-		service: docker.Manager{
-			FrpsImage: frpsImage,
-		},
+		service:  containerSvc,
 	}
-	for _, opt := range opts {
-		opt(h)
-	}
+
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", handleHealth)
 	mux.HandleFunc("POST /deployment", h.handlePostDeployment)

--- a/provisioning/internal/api/handler.go
+++ b/provisioning/internal/api/handler.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"crypto/sha256"
-	"fmt"
 	"net/http"
 
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
@@ -44,13 +43,15 @@ func authRequest(keys *state.KeyStore, next http.Handler) http.Handler {
 			return
 		}
 
-		incoming, err := getAuthToken(r)
-		if err != nil {
+		bearer := r.Header.Get("Authorization")
+		if len(bearer) < 8 || bearer[:7] != "Bearer " {
+
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}
 
-		key, ok := keys.Lookup(incoming)
+		token := sha256.Sum256([]byte(bearer[7:]))
+		key, ok := keys.Lookup(token)
 		if !ok {
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
@@ -59,14 +60,4 @@ func authRequest(keys *state.KeyStore, next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), apiKeyContextKey, key)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
-}
-
-func getAuthToken(r *http.Request) ([32]byte, error) {
-	bearer := r.Header.Get("Authorization")
-	if len(bearer) < 8 || bearer[:7] != "Bearer " {
-		return [32]byte{}, fmt.Errorf("invalid auth token")
-	}
-
-	token := sha256.Sum256([]byte(bearer[7:]))
-	return token, nil
 }

--- a/provisioning/internal/state/keys.go
+++ b/provisioning/internal/state/keys.go
@@ -1,0 +1,96 @@
+package state
+
+import (
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+type APIKey struct {
+	ID            string     `json:"id"`
+	Label         string     `json:"label"`
+	HashHex       string     `json:"hash"` // SHA256 of key
+	CreatedAt     time.Time  `json:"created_at"`
+	ExpiresAt     *time.Time `json:"expires_at"`     // nil - does not expire
+	MaxConcurrent int        `json:"max_concurrent"` // 0 - no limit
+	Revoked       bool       `json:"revoked"`
+}
+
+type keysState struct {
+	Keys []APIKey `json:"keys"`
+}
+
+type KeyStore struct {
+	mu    sync.Mutex
+	path  string
+	state keysState
+}
+
+func NewKeyStore(path string) (*KeyStore, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, fmt.Errorf("failed to create state directory: %w", err)
+	}
+
+	ks := &KeyStore{
+		path:  path,
+		state: keysState{Keys: make([]APIKey, 0)},
+	}
+	if err := ks.load(); err != nil {
+		return nil, err
+	}
+	return ks, nil
+}
+
+func (ks *KeyStore) Lookup(hash [32]byte) (APIKey, bool) {
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+
+	for _, k := range ks.state.Keys {
+		decoded, err := hex.DecodeString(k.HashHex)
+		if err != nil {
+			continue
+		}
+
+		if subtle.ConstantTimeCompare(hash[:], decoded) != 1 {
+			continue
+		}
+		if k.Revoked {
+			return APIKey{}, false
+		}
+		if k.ExpiresAt != nil && time.Now().After(*k.ExpiresAt) {
+			return APIKey{}, false
+		}
+		return k, true
+	}
+
+	return APIKey{}, false
+}
+
+func (ks *KeyStore) load() error {
+	data, err := os.ReadFile(ks.path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error reading keys file: %w", err)
+	}
+	return json.Unmarshal(data, &ks.state)
+}
+
+func (ks *KeyStore) save() error {
+	data, err := json.MarshalIndent(ks.state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal error: %w", err)
+	}
+
+	tmp := ks.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("write file error: %w", err)
+	}
+	return os.Rename(tmp, ks.path)
+}

--- a/provisioning/internal/state/keys.go
+++ b/provisioning/internal/state/keys.go
@@ -13,8 +13,9 @@ import (
 
 type APIKey struct {
 	ID            string     `json:"id"`
-	Label         string     `json:"label"`
-	HashHex       string     `json:"hash"` // SHA256 of key
+	OwnerID       string     `json:"owner_id"`
+	Label         string     `json:"label"` // human-redable key purpose ("internal-testing")
+	HashHex       string     `json:"hash"`  // SHA256 of key
 	CreatedAt     time.Time  `json:"created_at"`
 	ExpiresAt     *time.Time `json:"expires_at"`     // nil - does not expire
 	MaxConcurrent int        `json:"max_concurrent"` // 0 - no limit

--- a/provisioning/internal/state/keys.go
+++ b/provisioning/internal/state/keys.go
@@ -1,6 +1,7 @@
 package state
 
 import (
+	"bytes"
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
@@ -77,10 +78,14 @@ func (ks *KeyStore) load() error {
 	if os.IsNotExist(err) {
 		return nil
 	}
+
 	if err != nil {
 		return fmt.Errorf("error reading keys file: %w", err)
 	}
-	return json.Unmarshal(data, &ks.state)
+
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(&ks.state)
 }
 
 func (ks *KeyStore) save() error {

--- a/provisioning/internal/state/keys_test.go
+++ b/provisioning/internal/state/keys_test.go
@@ -1,0 +1,156 @@
+package state_test
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
+	"github.com/google/uuid"
+)
+
+func defaultKeyHash() [32]byte {
+	return sha256.Sum256([]byte("test-key"))
+}
+
+func defaultTestKey() state.APIKey {
+	hash := defaultKeyHash()
+	created := time.Now()
+	return state.APIKey{
+		ID:            uuid.NewString(),
+		OwnerID:       "tests",
+		Label:         "automated-testing",
+		HashHex:       hex.EncodeToString(hash[:]),
+		MaxConcurrent: 0,
+		Revoked:       false,
+		CreatedAt:     created,
+		ExpiresAt:     nil,
+	}
+}
+
+func newTestKeyStoreWithKey(t *testing.T, key state.APIKey) *state.KeyStore {
+	t.Helper()
+	data, err := json.Marshal(struct {
+		Keys []state.APIKey `json:"keys"`
+	}{Keys: []state.APIKey{key}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "keys.json")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+	ks, err := state.NewKeyStore(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ks
+}
+
+func newDefaultTestKeyStore(t *testing.T) *state.KeyStore {
+	t.Helper()
+	return newTestKeyStoreWithKey(t, defaultTestKey())
+}
+
+func TestLookUpKey(t *testing.T) {
+	t.Run("valid-key", func(t *testing.T) {
+		ks := newDefaultTestKeyStore(t)
+		if _, ok := ks.Lookup(defaultKeyHash()); !ok {
+			t.Errorf("expected to find valid key")
+		}
+	})
+
+	t.Run("unknown", func(t *testing.T) {
+		ks := newDefaultTestKeyStore(t)
+		hash := sha256.Sum256([]byte("unknown-key"))
+		if _, ok := ks.Lookup(hash); ok {
+			t.Errorf("expected not to find key")
+		}
+	})
+
+	t.Run("revoked", func(t *testing.T) {
+		key := defaultTestKey()
+		key.Revoked = true
+		ks := newTestKeyStoreWithKey(t, key)
+
+		if _, ok := ks.Lookup(defaultKeyHash()); ok {
+			t.Errorf("expected key to be revoked")
+		}
+	})
+
+	t.Run("expired", func(t *testing.T) {
+		key := defaultTestKey()
+		expired := time.Now().Add(-time.Hour)
+		key.ExpiresAt = &expired
+		ks := newTestKeyStoreWithKey(t, key)
+
+		if _, ok := ks.Lookup(defaultKeyHash()); ok {
+			t.Errorf("expected key to be expired")
+		}
+	})
+
+	t.Run("future-expiry", func(t *testing.T) {
+		key := defaultTestKey()
+		expired := time.Now().Add(time.Hour)
+		key.ExpiresAt = &expired
+		ks := newTestKeyStoreWithKey(t, key)
+
+		if _, ok := ks.Lookup(defaultKeyHash()); !ok {
+			t.Errorf("expected key to be valid")
+		}
+	})
+
+	t.Run("malformed-hash", func(t *testing.T) {
+		key := defaultTestKey()
+		key.HashHex = "not-hex-value"
+		ks := newTestKeyStoreWithKey(t, key)
+
+		if _, ok := ks.Lookup(defaultKeyHash()); ok {
+			t.Errorf("expected key to be invalid")
+		}
+	})
+}
+
+func TestKeysFile(t *testing.T) {
+	t.Run("no-existing-keys-file", func(t *testing.T) {
+		ks, err := state.NewKeyStore(filepath.Join(t.TempDir(), "state.json"))
+		if err != nil {
+			t.Fatalf("failed to create blank keystore")
+		}
+
+		if _, ok := ks.Lookup(defaultKeyHash()); ok {
+			t.Errorf("expected no key")
+		}
+	})
+
+	t.Run("invalid-json", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "keys.json")
+		if err := os.WriteFile(path, []byte("not valid json"), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := state.NewKeyStore(path); err == nil {
+			t.Errorf("no error thrown on broken data")
+		}
+	})
+
+	t.Run("unexpected-json", func(t *testing.T) {
+		data, err := json.Marshal(struct{ Foo string }{Foo: "invalid content"})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		path := filepath.Join(t.TempDir(), "keys.json")
+		if err := os.WriteFile(path, data, 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := state.NewKeyStore(path); err == nil {
+			t.Errorf("no error thrown on broken data")
+		}
+	})
+}

--- a/provisioning/internal/state/keys_test.go
+++ b/provisioning/internal/state/keys_test.go
@@ -58,9 +58,15 @@ func newDefaultTestKeyStore(t *testing.T) *state.KeyStore {
 
 func TestLookUpKey(t *testing.T) {
 	t.Run("valid-key", func(t *testing.T) {
-		ks := newDefaultTestKeyStore(t)
-		if _, ok := ks.Lookup(defaultKeyHash()); !ok {
+		storedKey := defaultTestKey()
+		ks := newTestKeyStoreWithKey(t, storedKey)
+		key, ok := ks.Lookup(defaultKeyHash())
+		if !ok {
 			t.Errorf("expected to find valid key")
+		}
+
+		if key.ID != storedKey.ID {
+			t.Errorf("key.ID mismatch: expected %s, got %s", storedKey.ID, key.ID)
 		}
 	})
 

--- a/provisioning/internal/state/registry.go
+++ b/provisioning/internal/state/registry.go
@@ -17,6 +17,7 @@ type Deployment struct {
 	Token     string    `json:"token"`
 	FrpsPort  int       `json:"frps_port"`
 	CreatedAt time.Time `json:"created_at"`
+	OwnerID   string    `json:"owner_id"`
 }
 
 type registryState struct {
@@ -47,13 +48,21 @@ func New(path string, portMin, portMax int) (*Registry, error) {
 	return r, nil
 }
 
-func (r *Registry) AllocatePort(slug, token string) (Deployment, error) {
+func (r *Registry) AllocatePort(slug, token, ownerID string, maxConcurrent int) (Deployment, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	used := make(map[int]bool)
+	var count int
 	for _, d := range r.state.Deployments {
 		used[d.FrpsPort] = true
+		if d.OwnerID == ownerID {
+			count++
+		}
+	}
+
+	if maxConcurrent != 0 && count >= maxConcurrent {
+		return Deployment{}, fmt.Errorf("max deployments reached")
 	}
 
 	for port := r.portMin; port <= r.portMax; port++ {
@@ -63,6 +72,7 @@ func (r *Registry) AllocatePort(slug, token string) (Deployment, error) {
 				Token:     token,
 				FrpsPort:  port,
 				CreatedAt: time.Now().UTC(),
+				OwnerID:   ownerID,
 			}
 			r.state.Deployments[slug] = d
 			return d, r.save()

--- a/provisioning/internal/state/registry_test.go
+++ b/provisioning/internal/state/registry_test.go
@@ -26,17 +26,24 @@ func defaultTestRegistry(t *testing.T) *state.Registry {
 func TestAllocatePort(t *testing.T) {
 	reg := defaultTestRegistry(t)
 
-	d, err := reg.AllocatePort(testSlug, "test-token", "test-owner", 0)
+	created, err := reg.AllocatePort(testSlug, "test-token", "test-owner", 0)
 	if err != nil {
 		t.Errorf("expected valid allocation")
 	}
 
-	if d.FrpsPort < minPort || d.FrpsPort > maxPort {
-		t.Errorf("port allocated outside of permitted range: %d", d.FrpsPort)
+	if created.FrpsPort < minPort || created.FrpsPort > maxPort {
+		t.Errorf("port allocated outside of permitted range: %d", created.FrpsPort)
 	}
 
-	if _, ok := reg.Get(d.Slug); !ok {
-		t.Errorf("valid deployment expected")
+	found, ok := reg.Get(created.Slug)
+	if !ok {
+		t.Fatal("expected deployment to exist")
+	}
+	if found.FrpsPort != created.FrpsPort {
+		t.Errorf("expected port %d, got %d", created.FrpsPort, found.FrpsPort)
+	}
+	if found.OwnerID != "test-owner" {
+		t.Errorf("expected owner %q, got %q", "test-owner", found.OwnerID)
 	}
 
 	if _, ok := reg.Get("some-random-slug"); ok {
@@ -108,7 +115,8 @@ func TestRegistryPersistence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := reg.AllocatePort(testSlug, "test-token", "test-owner", 0); err != nil {
+	created, err := reg.AllocatePort(testSlug, "test-token", "test-owner", 0)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -117,7 +125,14 @@ func TestRegistryPersistence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := reg2.Get(testSlug); !ok {
+	found, ok := reg2.Get(testSlug)
+	if !ok {
 		t.Errorf("port allocation did not persist between restarts")
+	}
+	if found.FrpsPort != created.FrpsPort {
+		t.Errorf("expected port %d, got %d", created.FrpsPort, found.FrpsPort)
+	}
+	if found.OwnerID != "test-owner" {
+		t.Errorf("expected owner %q, got %q", "test-owner", found.OwnerID)
 	}
 }

--- a/provisioning/internal/state/registry_test.go
+++ b/provisioning/internal/state/registry_test.go
@@ -1,0 +1,123 @@
+package state_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
+)
+
+const (
+	testSlug = "test-slug"
+	minPort  = 7000
+	maxPort  = 7010
+)
+
+func defaultTestRegistry(t *testing.T) *state.Registry {
+	t.Helper()
+	reg, err := state.New(filepath.Join(t.TempDir(), "state.json"), minPort, maxPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return reg
+}
+
+func TestAllocatePort(t *testing.T) {
+	reg := defaultTestRegistry(t)
+
+	d, err := reg.AllocatePort(testSlug, "test-token", "test-owner", 0)
+	if err != nil {
+		t.Errorf("expected valid allocation")
+	}
+
+	if d.FrpsPort < minPort || d.FrpsPort > maxPort {
+		t.Errorf("port allocated outside of permitted range: %d", d.FrpsPort)
+	}
+
+	if _, ok := reg.Get(d.Slug); !ok {
+		t.Errorf("valid deployment expected")
+	}
+
+	if _, ok := reg.Get("some-random-slug"); ok {
+		t.Error("retrieved a slug that was never allocated")
+	}
+}
+
+func TestRelease(t *testing.T) {
+	reg := defaultTestRegistry(t)
+	d, err := reg.AllocatePort(testSlug, "test-token", "test-owner", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := reg.Release(d.Slug); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, ok := reg.Get(d.Slug); ok {
+		t.Errorf("%s expected to be released", d.Slug)
+	}
+
+	if err := reg.Release(d.Slug); err == nil {
+		t.Errorf("%s expected to already be released", d.Slug)
+	}
+
+	if err := reg.Release("random-slug"); err == nil {
+		t.Error("released slug that was never allocated")
+	}
+}
+
+func TestMaxConcurrent(t *testing.T) {
+	t.Run("single-owner", func(t *testing.T) {
+		const maxDeploys = 1
+		reg := defaultTestRegistry(t)
+		if _, err := reg.AllocatePort("testSlug-A", "test-token", "test-owner", maxDeploys); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := reg.AllocatePort("testSlug-B", "test-token", "test-owner", maxDeploys); err == nil {
+			t.Errorf("deployed more than %d max deployments", maxDeploys)
+		}
+	})
+
+	t.Run("multiple-owners", func(t *testing.T) {
+		const maxDeploys = 1
+		reg := defaultTestRegistry(t)
+		if _, err := reg.AllocatePort("testSlug-A", "test-token", "test-owner-0", maxDeploys); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := reg.AllocatePort("testSlug-B", "test-token", "test-owner-1", maxDeploys); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := reg.AllocatePort("testSlug-C", "test-token", "test-owner-0", maxDeploys); err == nil {
+			t.Errorf("test-owner-0 deployed more than %d max deployments", maxDeploys)
+		}
+
+		if _, err := reg.AllocatePort("testSlug-D", "test-token", "test-owner-1", maxDeploys); err == nil {
+			t.Errorf("test-owner-1 deployed more than %d max deployments", maxDeploys)
+		}
+	})
+}
+
+func TestRegistryPersistence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	reg, err := state.New(path, minPort, maxPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reg.AllocatePort(testSlug, "test-token", "test-owner", 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// create a new registry with the same file path as before to simulate a restart
+	reg2, err := state.New(path, minPort, maxPort)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := reg2.Get(testSlug); !ok {
+		t.Errorf("port allocation did not persist between restarts")
+	}
+}


### PR DESCRIPTION
## Per-customer API keys for provisioner  

#184 

Replaces the single shared test API key with valid keys per customer which can be rotated, revoked, or expired.  We can also control the max number of deployments each customer is permitted to create.
