### PR TITLE
chore: merge .provisioner.env and .env

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,7 +9,6 @@ vars:
 
 dotenv:
   - .env
-  - .provisioner.env
 
 silent: true
 
@@ -204,28 +203,28 @@ tasks:
         - PROVISIONER_API_KEY
     cmds:
       - cmd: >
-          grep -s PROVISIONER_API_KEY .provisioner.env &&
-          sed -i "s/^PROVISIONER_API_KEY=.*$/PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}/" .provisioner.env ||
-          echo "PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}" >> .provisioner.env
+          grep -s PROVISIONER_API_KEY .env &&
+          sed -i "s/^PROVISIONER_API_KEY=.*$/PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}/" .env ||
+          echo "PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}" >> .env
         platforms: [linux]
       - cmd: >
-          grep -s PROVISIONER_API_KEY .provisioner.env &&
-          sed -i '' "s/^PROVISIONER_API_KEY=.*$/PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}/" .provisioner.env ||
-          echo "PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}" >> .provisioner.env
+          grep -s PROVISIONER_API_KEY .env &&
+          sed -i '' "s/^PROVISIONER_API_KEY=.*$/PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}/" .env ||
+          echo "PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}" >> .env
         platforms: [darwin]
       - cmd: >
           powershell -Command
-          "if (Select-String -Path '.provisioner.env' -Pattern '^PROVISIONER_API_KEY=' -Quiet) { (Get-Content '.provisioner.env') -replace '^PROVISIONER_API_KEY=.*$', 'PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}' | Set-Content '.provisioner.env' } else { Add-Content '.provisioner.env' 'PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}' }"
+          "if (Select-String -Path '.env' -Pattern '^PROVISIONER_API_KEY=' -Quiet) { (Get-Content '.env') -replace '^PROVISIONER_API_KEY=.*$', 'PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}' | Set-Content '.env' } else { Add-Content '.provisioner.env' 'PROVISIONER_API_KEY={{.PROVISIONER_API_KEY}}' }"
         platforms: [windows]
     deps:
-      - createProvisionerEnv
+      - createDotEnv
 
   autoDomain:
     internal: true
     if: 'grep -q "PROXY_DOMAIN_TYPE=Automatic" .env 2>/dev/null && [ -z "$MESH_SUBDOMAIN" ]'
     cmds:
       - |
-        [ -f .provisioner.env ] && . ./.provisioner.env
+        [ -f .env ] && . ./.env
         if [ -z "$PROVISIONER_API_KEY" ]; then
           printf "\033[1;31mMissing provisioner API key. Run task controlPlane to set it up.\033[0m\n"
           exit 1
@@ -343,7 +342,3 @@ tasks:
   createDotEnv:
     internal: true
     cmd: '[ -f .env ] || (touch .env && chmod 600 .env)'
-
-  createProvisionerEnv:
-    internal: true
-    cmd: '[ -f .provisioner.env ] || (touch .provisioner.env && chmod 600 .provisioner.env)'

--- a/provisioning/provisioner.env.example
+++ b/provisioning/provisioner.env.example
@@ -1,7 +1,6 @@
 FRPS_IMAGE=snowdreamtech/frps:latest
 FRPS_PORT_MIN=7000
 FRPS_PORT_MAX=7100
-PROVISIONER_API_KEY=random 32 byte api key
 TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL=porkbun account email
 PORKBUN_API_KEY=generated in porkbun account settings
 PORKBUN_SECRET_API_KEY=generated in porkbun account settings


### PR DESCRIPTION
Original design had .provisioner.env carry more weight than a single variable, now it's only the provisioner api key so makes more sense to keep all variables in one file for easier setup and teardown.  
Also removed PROVISIONER_API_KEY from example server .env file - keys are now managed by a keystore rather than a single shared secret.