### PR TITLE
Provisioner Admin: Add KeyStore Create method

### DIFF
--- a/provisioning/cmd/server/admin/main.go
+++ b/provisioning/cmd/server/admin/main.go
@@ -1,0 +1,1 @@
+package admin

--- a/provisioning/internal/state/keys.go
+++ b/provisioning/internal/state/keys.go
@@ -2,7 +2,10 @@ package state
 
 import (
 	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -10,6 +13,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type APIKey struct {
@@ -71,6 +76,46 @@ func (ks *KeyStore) Lookup(hash [32]byte) (APIKey, bool) {
 	}
 
 	return APIKey{}, false
+}
+
+func (ks *KeyStore) Create(ownerID, label string, maxConcurrent int, ttl *time.Duration) (APIKey, string, error) {
+	key := make([]byte, 32)
+	_, err := rand.Read(key)
+	if err != nil {
+		return APIKey{}, "", err
+	}
+
+	b64Key := base64.URLEncoding.EncodeToString(key)
+	hash := sha256.Sum256([]byte(b64Key))
+	hashHex := hex.EncodeToString(hash[:])
+	createdAt := time.Now().UTC()
+	var expiresAt *time.Time
+	if ttl != nil {
+		t := createdAt.Add(*ttl)
+		expiresAt = &t
+	}
+
+	apiKey := APIKey{
+		ID:            uuid.NewString(),
+		OwnerID:       ownerID,
+		Label:         label,
+		MaxConcurrent: maxConcurrent,
+		Revoked:       false,
+		HashHex:       hashHex,
+		CreatedAt:     createdAt,
+		ExpiresAt:     expiresAt,
+	}
+
+	ks.mu.Lock()
+	defer ks.mu.Unlock()
+
+	ks.state.Keys = append(ks.state.Keys, apiKey)
+	if err := ks.save(); err != nil {
+		ks.state.Keys = ks.state.Keys[:len(ks.state.Keys)-1]
+		return APIKey{}, "", err
+	}
+
+	return apiKey, b64Key, nil
 }
 
 func (ks *KeyStore) load() error {

--- a/provisioning/internal/state/keys_test.go
+++ b/provisioning/internal/state/keys_test.go
@@ -160,3 +160,97 @@ func TestKeysFile(t *testing.T) {
 		}
 	})
 }
+
+func TestCreate(t *testing.T) {
+	t.Run("valid-no-ttl", func(t *testing.T) {
+		keystore := newDefaultTestKeyStore(t)
+		ownerID := "new-owner-id"
+		label := "internal-testing"
+		maxConcurrent := 0
+		k, b64Key, err := keystore.Create(ownerID, label, maxConcurrent, nil)
+		if err != nil {
+			t.Errorf("failed to create valid key: %v", err)
+		}
+
+		if k.OwnerID != ownerID {
+			t.Errorf("expected OwnerID '%s', got '%s'", ownerID, k.OwnerID)
+		}
+
+		if k.Label != label {
+			t.Errorf("expected Label '%s', got '%s'", label, k.Label)
+		}
+
+		if k.MaxConcurrent != maxConcurrent {
+			t.Errorf("expected MaxConcurrent '%d', got '%d'", maxConcurrent, k.MaxConcurrent)
+		}
+
+		if k.Revoked {
+			t.Error("created key is revoked")
+		}
+
+		if k.ID == "" {
+			t.Error("key created with blank ID")
+		}
+
+		keyHash := sha256.Sum256([]byte(b64Key))
+		found, ok := keystore.Lookup(keyHash)
+		if !ok {
+			t.Errorf("failed to lookup created key")
+		}
+
+		if found.ID != k.ID {
+			t.Errorf("key IDs do not match")
+		}
+	})
+
+	t.Run("valid-with-ttl", func(t *testing.T) {
+		keystore := newDefaultTestKeyStore(t)
+		ownerID := "new-owner-id"
+		label := "internal-testing"
+		maxConcurrent := 0
+		d := time.Duration(time.Hour)
+		ttl := &d
+		k, _, err := keystore.Create(ownerID, label, maxConcurrent, ttl)
+		if err != nil {
+			t.Errorf("failed to create valid key: %v", err)
+		}
+
+		if k.ExpiresAt == nil {
+			t.Errorf("key expected to have an expiry time")
+		}
+
+		remaining := time.Until(*k.ExpiresAt)
+		if remaining < d-time.Second || remaining > d+time.Second {
+			t.Errorf("key expiry time is not within tolerance")
+		}
+	})
+
+	t.Run("persistance", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "keys.json")
+		keystore, err := state.NewKeyStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ownerID := "new-owner-id"
+		label := "internal-testing"
+		maxConcurrent := 0
+		createdKey, b64Key, err := keystore.Create(ownerID, label, maxConcurrent, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		keyStore2, err := state.NewKeyStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		keyHash := sha256.Sum256([]byte(b64Key))
+		foundKey, ok := keyStore2.Lookup(keyHash)
+		if !ok {
+			t.Errorf("key did not persist between keystores")
+		}
+
+		if createdKey.ID != foundKey.ID {
+			t.Errorf("key IDs do not match")
+		}
+	})
+}


### PR DESCRIPTION
### Summary
Adding the admin functions for provisioner API keys.  

In this PR: `Create()`
To come: 
- `Revoke()`: Delete an existing key
- `Update()`: Partial updates for existing keys - changing label, updating expiry time etc.