### PR TITLE
Bug/provisioner path traversal

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -182,6 +182,7 @@ github.com/gokrazy/serial-busybox v0.0.0-20250119153030-ac58ba7574e7/go.mod h1:O
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/mock v1.7.0-rc.1/go.mod h1:s42URUywIqd+OcERslBJvOjepvNymP31m3q8d/GkuRs=
+github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangci/dupl v0.0.0-20180902072040-3e9179ac440a/go.mod h1:ryS0uhF+x9jgbj/N71xsEqODy9BN81/GonCZiOzirOk=
@@ -456,6 +457,7 @@ golang.org/x/net v0.50.0/go.mod h1:UgoSli3F/pBgdJBHCTc+tp3gmrU4XswgGRgtnwWTfyM=
 golang.org/x/net v0.51.0/go.mod h1:aamm+2QF5ogm02fjy5Bb7CQ0WMt1/WVM7FtyaTLlA9Y=
 golang.org/x/oauth2 v0.35.0 h1:Mv2mzuHuZuY2+bkyWXIHMfhNdJAdwW3FuWeCPYN5GVQ=
 golang.org/x/oauth2 v0.35.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=
+golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 golang.org/x/sys v0.33.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=

--- a/provisioning/internal/api/deployment.go
+++ b/provisioning/internal/api/deployment.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
 )
@@ -73,6 +74,11 @@ func (h *handler) handleDeleteDeployment(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	if !confirmValidSlug(slug) {
+		http.Error(w, "invalid slug", http.StatusBadRequest)
+		return
+	}
+
 	if err := h.service.Stop(slug); err != nil {
 		http.Error(w, fmt.Sprintf("failed to stop container: %v", err), http.StatusInternalServerError)
 		return
@@ -83,4 +89,10 @@ func (h *handler) handleDeleteDeployment(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	w.WriteHeader(http.StatusOK)
+}
+
+func confirmValidSlug(slug string) bool {
+	// 10 lowercase hex characters
+	slugPattern := regexp.MustCompile(`^[0-9a-f]{10}$`)
+	return slugPattern.MatchString(slug)
 }

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -349,7 +349,10 @@ func TestDeleteDeployment(t *testing.T) {
 		expected int
 	}{
 		{"ok", created.Slug, http.StatusOK},
-		{"slug does not exist", "wrong-slug", http.StatusNotFound},
+		{"slug does not exist", "abc123def4", http.StatusNotFound},
+		{"invalid slug format raw", "foo/bar", http.StatusNotFound},
+		{"invalid slug format encoded", "foo%2Fbar", http.StatusBadRequest},
+		{"traversal via dotdot", "%2e%2e", http.StatusBadRequest},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary
Fix for: Path traversal in DELETE /deployment/{slug} → arbitrary directory deletion as root, including the API keystore and all tenant state (verified exploitable)