### PR TITLE
Add auth to admin API

### DIFF
--- a/provisioning/cmd/admin/main.go
+++ b/provisioning/cmd/admin/main.go
@@ -20,6 +20,11 @@ func main() {
 		log.Fatal("HOST_DATA_PATH must be set")
 	}
 
+	adminToken := os.Getenv("ADMIN_TOKEN")
+	if adminToken == "" {
+		log.Fatal("ADMIN_TOKEN must be set")
+	}
+
 	keyStore, err := state.NewKeyStore(filepath.Join(dataPath, "keys.json"))
 	if err != nil {
 		log.Fatal("failed to initialise key store")
@@ -27,7 +32,7 @@ func main() {
 
 	srv := &http.Server{
 		Addr:         ":9090",
-		Handler:      adminapi.NewAdminRouter(keyStore),
+		Handler:      adminapi.NewAdminRouter(keyStore, adminToken),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}

--- a/provisioning/compose.yml
+++ b/provisioning/compose.yml
@@ -28,6 +28,8 @@ services:
       dockerfile: provisioning/Dockerfile
     command: ["/admin"]
     profiles: [admin]
+    env_file:
+      - provisioner.env
     environment:
       - HOST_DATA_PATH=/var/lib/mesh-provisioner
     ports:

--- a/provisioning/internal/adminapi/handler.go
+++ b/provisioning/internal/adminapi/handler.go
@@ -1,6 +1,8 @@
 package adminapi
 
 import (
+	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -50,7 +52,7 @@ type handler struct {
 	keys *state.KeyStore
 }
 
-func NewAdminRouter(keys *state.KeyStore) http.Handler {
+func NewAdminRouter(keys *state.KeyStore, adminToken string) http.Handler {
 	h := &handler{
 		keys: keys,
 	}
@@ -61,7 +63,26 @@ func NewAdminRouter(keys *state.KeyStore) http.Handler {
 	mux.HandleFunc("DELETE /keys/{key_id}", h.handleDeleteKey)
 	mux.HandleFunc("PATCH /keys/{key_id}", h.handlePatchKey)
 
-	return mux
+	return authRequest(adminToken, mux)
+}
+
+func authRequest(adminToken string, next http.Handler) http.Handler {
+	expected := sha256.Sum256([]byte(adminToken))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bearer := r.Header.Get("Authorization")
+		if len(bearer) < 8 || bearer[:7] != "Bearer " {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		token := sha256.Sum256([]byte(bearer[7:]))
+		if subtle.ConstantTimeCompare(token[:], expected[:]) != 1 {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
 }
 
 func (h *handler) handleGetKeys(w http.ResponseWriter, r *http.Request) {

--- a/provisioning/internal/adminapi/handler_test.go
+++ b/provisioning/internal/adminapi/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -12,6 +13,8 @@ import (
 
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
 )
+
+const testAdminToken = "test-admin-token"
 
 func newTestKeyStore(t *testing.T) *state.KeyStore {
 	t.Helper()
@@ -24,7 +27,13 @@ func newTestKeyStore(t *testing.T) *state.KeyStore {
 
 func newTestAdminRouter(t *testing.T) http.Handler {
 	t.Helper()
-	return NewAdminRouter(newTestKeyStore(t))
+	return NewAdminRouter(newTestKeyStore(t), testAdminToken)
+}
+
+func newAuthedRequest(method, target string, body io.Reader) *http.Request {
+	req := httptest.NewRequest(method, target, body)
+	req.Header.Set("Authorization", "Bearer "+testAdminToken)
+	return req
 }
 
 func createPatchTestKey(t *testing.T, router http.Handler) createKeyResponse {
@@ -40,7 +49,7 @@ func createPatchTestKey(t *testing.T, router http.Handler) createKeyResponse {
 		t.Fatal(err)
 	}
 
-	createReq := httptest.NewRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
+	createReq := newAuthedRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, createReq)
 	if w.Code != http.StatusCreated {
@@ -55,7 +64,7 @@ func createPatchTestKey(t *testing.T, router http.Handler) createKeyResponse {
 
 func listKeys(t *testing.T, router http.Handler) getKeysResponse {
 	t.Helper()
-	getReq := httptest.NewRequest(http.MethodGet, "/keys", nil)
+	getReq := newAuthedRequest(http.MethodGet, "/keys", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, getReq)
 	if w.Code != http.StatusOK {
@@ -84,7 +93,7 @@ func TestCreateKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
+		req := newAuthedRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		router := newTestAdminRouter(t)
 		router.ServeHTTP(w, req)
@@ -121,7 +130,7 @@ func TestCreateKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
+		req := newAuthedRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		newTestAdminRouter(t).ServeHTTP(w, req)
 		if w.Code != http.StatusCreated {
@@ -144,7 +153,7 @@ func TestCreateKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
+		req := newAuthedRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		newTestAdminRouter(t).ServeHTTP(w, req)
 		if w.Code != http.StatusBadRequest {
@@ -154,7 +163,7 @@ func TestCreateKey(t *testing.T) {
 
 	t.Run("malformed-json", func(t *testing.T) {
 		b := []byte("not json")
-		req := httptest.NewRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
+		req := newAuthedRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		newTestAdminRouter(t).ServeHTTP(w, req)
 		if w.Code != http.StatusBadRequest {
@@ -171,7 +180,7 @@ func TestCreateKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
+		req := newAuthedRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		newTestAdminRouter(t).ServeHTTP(w, req)
 		if w.Code != http.StatusBadRequest {
@@ -188,7 +197,7 @@ func TestCreateKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
+		req := newAuthedRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		newTestAdminRouter(t).ServeHTTP(w, req)
 		if w.Code != http.StatusBadRequest {
@@ -206,7 +215,7 @@ func TestCreateKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		req := httptest.NewRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
+		req := newAuthedRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		newTestAdminRouter(t).ServeHTTP(w, req)
 		if w.Code != http.StatusBadRequest {
@@ -230,7 +239,7 @@ func TestDeleteKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		createReq := httptest.NewRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
+		createReq := newAuthedRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		router := newTestAdminRouter(t)
 		router.ServeHTTP(w, createReq)
@@ -243,7 +252,7 @@ func TestDeleteKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		deleteReq := httptest.NewRequest(http.MethodDelete, fmt.Sprintf("/keys/%s", created.ID), nil)
+		deleteReq := newAuthedRequest(http.MethodDelete, fmt.Sprintf("/keys/%s", created.ID), nil)
 		w = httptest.NewRecorder()
 		router.ServeHTTP(w, deleteReq)
 		if w.Code != http.StatusOK {
@@ -257,7 +266,7 @@ func TestDeleteKey(t *testing.T) {
 	})
 
 	t.Run("unknown-key", func(t *testing.T) {
-		deleteReq := httptest.NewRequest(http.MethodDelete, "/keys/unknown-id", nil)
+		deleteReq := newAuthedRequest(http.MethodDelete, "/keys/unknown-id", nil)
 		w := httptest.NewRecorder()
 		newTestAdminRouter(t).ServeHTTP(w, deleteReq)
 		if w.Code != http.StatusNotFound {
@@ -280,7 +289,7 @@ func TestPatchKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		patchReq := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/keys/%s", created.ID), bytes.NewBuffer(b))
+		patchReq := newAuthedRequest(http.MethodPatch, fmt.Sprintf("/keys/%s", created.ID), bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, patchReq)
 		if w.Code != http.StatusOK {
@@ -304,7 +313,7 @@ func TestPatchKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		patchReq := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/keys/%s", created.ID), bytes.NewBuffer(b))
+		patchReq := newAuthedRequest(http.MethodPatch, fmt.Sprintf("/keys/%s", created.ID), bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, patchReq)
 		if w.Code != http.StatusOK {
@@ -329,7 +338,7 @@ func TestPatchKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		patchReq := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/keys/%s", created.ID), bytes.NewBuffer(b))
+		patchReq := newAuthedRequest(http.MethodPatch, fmt.Sprintf("/keys/%s", created.ID), bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, patchReq)
 		if w.Code != http.StatusOK {
@@ -355,7 +364,7 @@ func TestPatchKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		patchReq := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/keys/%s", created.ID), bytes.NewBuffer(b))
+		patchReq := newAuthedRequest(http.MethodPatch, fmt.Sprintf("/keys/%s", created.ID), bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, patchReq)
 		if w.Code != http.StatusOK {
@@ -382,7 +391,7 @@ func TestPatchKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		patchReq := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/keys/%s", response.ID), bytes.NewBuffer(b))
+		patchReq := newAuthedRequest(http.MethodPatch, fmt.Sprintf("/keys/%s", response.ID), bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, patchReq)
 		if w.Code != http.StatusBadRequest {
@@ -401,7 +410,7 @@ func TestPatchKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		patchReq := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/keys/%s", response.ID), bytes.NewBuffer(b))
+		patchReq := newAuthedRequest(http.MethodPatch, fmt.Sprintf("/keys/%s", response.ID), bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		router.ServeHTTP(w, patchReq)
 		if w.Code != http.StatusBadRequest {
@@ -415,11 +424,47 @@ func TestPatchKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		patchReq := httptest.NewRequest(http.MethodPatch, "/keys/unknown-id", bytes.NewBuffer(b))
+		patchReq := newAuthedRequest(http.MethodPatch, "/keys/unknown-id", bytes.NewBuffer(b))
 		w := httptest.NewRecorder()
 		newTestAdminRouter(t).ServeHTTP(w, patchReq)
 		if w.Code != http.StatusNotFound {
 			t.Errorf("expected %d, got %d", http.StatusNotFound, w.Code)
+		}
+	})
+}
+
+func TestAdminAuth(t *testing.T) {
+	router := newTestAdminRouter(t)
+
+	cases := []struct {
+		name   string
+		header string
+	}{
+		{"no header", ""},
+		{"malformed header", testAdminToken},
+		{"wrong token", "Bearer wrong-token"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/keys", nil)
+			if tc.header != "" {
+				req.Header.Set("Authorization", tc.header)
+			}
+			w := httptest.NewRecorder()
+			router.ServeHTTP(w, req)
+			if w.Code != http.StatusUnauthorized {
+				t.Errorf("expected %d, got %d", http.StatusUnauthorized, w.Code)
+			}
+		})
+	}
+
+	t.Run("valid token", func(t *testing.T) {
+		req := newAuthedRequest(http.MethodGet, "/keys", nil)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Errorf("expected %d, got %d", http.StatusOK, w.Code)
 		}
 	})
 }

--- a/provisioning/internal/api/handler.go
+++ b/provisioning/internal/api/handler.go
@@ -45,7 +45,6 @@ func authRequest(keys *state.KeyStore, next http.Handler) http.Handler {
 
 		bearer := r.Header.Get("Authorization")
 		if len(bearer) < 8 || bearer[:7] != "Bearer " {
-
 			http.Error(w, "unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/provisioning/provisioner.env.example
+++ b/provisioning/provisioner.env.example
@@ -4,3 +4,4 @@ FRPS_PORT_MAX=7100
 TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL=porkbun account email
 PORKBUN_API_KEY=generated in porkbun account settings
 PORKBUN_SECRET_API_KEY=generated in porkbun account settings
+ADMIN_TOKEN=generate with `openssl rand -hex 32`


### PR DESCRIPTION
## Summary
Fix for: Admin/key-management API has no authentication; security depends entirely on a compose port binding