### PR TITLE
fix: Split compose .env files

### DIFF
--- a/provisioning/.gitignore
+++ b/provisioning/.gitignore
@@ -1,1 +1,3 @@
 provisioner.env
+admin.env
+traefik.env

--- a/provisioning/admin.env.example
+++ b/provisioning/admin.env.example
@@ -1,0 +1,1 @@
+ADMIN_TOKEN=generate with `openssl rand -hex 32`

--- a/provisioning/compose.yml
+++ b/provisioning/compose.yml
@@ -29,7 +29,7 @@ services:
     command: ["/admin"]
     profiles: [admin]
     env_file:
-      - provisioner.env
+      - admin.env
     environment:
       - HOST_DATA_PATH=/var/lib/mesh-provisioner
     ports:
@@ -41,7 +41,7 @@ services:
     image: traefik:v3.7.5
     restart: unless-stopped
     env_file:
-      - provisioner.env
+      - traefik.env
     ports:
       - "443:443"
     volumes:

--- a/provisioning/provisioner.env.example
+++ b/provisioning/provisioner.env.example
@@ -1,7 +1,3 @@
 FRPS_IMAGE=snowdreamtech/frps:latest
 FRPS_PORT_MIN=7000
 FRPS_PORT_MAX=7100
-TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL=porkbun account email
-PORKBUN_API_KEY=generated in porkbun account settings
-PORKBUN_SECRET_API_KEY=generated in porkbun account settings
-ADMIN_TOKEN=generate with `openssl rand -hex 32`

--- a/provisioning/traefik.env.example
+++ b/provisioning/traefik.env.example
@@ -1,0 +1,3 @@
+TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL=porkbun account email
+PORKBUN_API_KEY=generated in porkbun account settings
+PORKBUN_SECRET_API_KEY=generated in porkbun account settings


### PR DESCRIPTION
## Summary
Fixes: DNS-provider (Porkbun) API credentials over-distributed to the provisioner via a shared env_file