### PR TITLE
Add rate limiting to provisioning API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/docker/go-connections v0.7.0
 	github.com/google/uuid v1.6.0
 	golang.org/x/mobile v0.0.0-20260217195705-b56b3793a9c4
+	golang.org/x/time v0.14.0
 	tailscale.com v1.94.1
 )
 
@@ -157,7 +158,6 @@ require (
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/term v0.42.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.44.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
 	golang.zx2c4.com/wireguard/windows v0.5.3 // indirect

--- a/provisioning/cmd/server/main.go
+++ b/provisioning/cmd/server/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/api"
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/docker"
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
+	"golang.org/x/time/rate"
 )
 
 // This is an intentionally light-weight and basic HTTP server
@@ -62,9 +63,12 @@ func main() {
 		log.Fatal("failed to initialise key store")
 	}
 
+	deploymentRateLimit := rate.Every(10 * time.Second)
+	deploymentRateBurst := 3
+	rateLimiter := api.NewLimiter(deploymentRateLimit, deploymentRateBurst)
 	srv := &http.Server{
 		Addr:         ":8080",
-		Handler:      api.NewRouter(keyStore, registry, docker.Manager{FrpsImage: frpsImage}),
+		Handler:      api.NewRouter(keyStore, registry, docker.Manager{FrpsImage: frpsImage}, rateLimiter),
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}

--- a/provisioning/internal/adminapi/handler.go
+++ b/provisioning/internal/adminapi/handler.go
@@ -116,7 +116,7 @@ func (h *handler) handlePostKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Label == "" || req.OwnerID == "" || req.MaxConcurrent < 0 {
+	if req.Label == "" || req.OwnerID == "" || req.MaxConcurrent <= 0 {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -173,8 +173,8 @@ func (h *handler) handlePatchKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	keyID := r.PathValue("key_id")
-	if req.MaxConcurrent != nil && *req.MaxConcurrent < 0 {
-		http.Error(w, "max_concurrent must be >= 0", http.StatusBadRequest)
+	if req.MaxConcurrent != nil && *req.MaxConcurrent <= 0 {
+		http.Error(w, "max_concurrent must be greater than 0", http.StatusBadRequest)
 		return
 	}
 

--- a/provisioning/internal/adminapi/handler_test.go
+++ b/provisioning/internal/adminapi/handler_test.go
@@ -41,7 +41,7 @@ func createPatchTestKey(t *testing.T, router http.Handler) createKeyResponse {
 	requestData := createKeyRequest{
 		OwnerID:       "test-owner",
 		Label:         "test-label",
-		MaxConcurrent: 0,
+		MaxConcurrent: 1,
 		TTLHours:      1,
 	}
 	b, err := json.Marshal(&requestData)
@@ -85,7 +85,7 @@ func TestCreateKey(t *testing.T) {
 		requestData := createKeyRequest{
 			OwnerID:       ownerId,
 			Label:         label,
-			MaxConcurrent: 0,
+			MaxConcurrent: 1,
 			TTLHours:      0,
 		}
 		b, err := json.Marshal(&requestData)
@@ -122,7 +122,7 @@ func TestCreateKey(t *testing.T) {
 		requestData := createKeyRequest{
 			OwnerID:       ownerId,
 			Label:         label,
-			MaxConcurrent: 0,
+			MaxConcurrent: 1,
 			TTLHours:      1,
 		}
 		b, err := json.Marshal(&requestData)
@@ -231,7 +231,7 @@ func TestDeleteKey(t *testing.T) {
 		requestData := createKeyRequest{
 			OwnerID:       ownerId,
 			Label:         label,
-			MaxConcurrent: 0,
+			MaxConcurrent: 1,
 			TTLHours:      0,
 		}
 		b, err := json.Marshal(&requestData)
@@ -323,7 +323,7 @@ func TestPatchKey(t *testing.T) {
 		listKeysResponse := listKeys(t, router)
 		if k, ok := listKeysResponse.Keys[created.ID]; !ok {
 			t.Fatalf("patched key is not present in GET keys")
-		} else if k.Label != created.Label || k.MaxConcurrent != 0 || !k.ExpiresAt.Equal(*created.ExpiresAt) {
+		} else if k.Label != created.Label || k.MaxConcurrent != 1 || !k.ExpiresAt.Equal(*created.ExpiresAt) {
 			t.Errorf("key has unexpected changes")
 		}
 	})
@@ -348,7 +348,7 @@ func TestPatchKey(t *testing.T) {
 		listKeysResponse := listKeys(t, router)
 		if k, ok := listKeysResponse.Keys[created.ID]; !ok {
 			t.Fatalf("patched key is not present in GET keys")
-		} else if k.Label != created.Label || k.MaxConcurrent != 0 || k.ExpiresAt != nil {
+		} else if k.Label != created.Label || k.MaxConcurrent != 1 || k.ExpiresAt != nil {
 			t.Errorf("key has unexpected changes")
 		}
 	})
@@ -374,7 +374,7 @@ func TestPatchKey(t *testing.T) {
 		listKeysResponse := listKeys(t, router)
 		if k, ok := listKeysResponse.Keys[created.ID]; !ok {
 			t.Fatalf("patched key is not present in GET keys")
-		} else if k.Label != created.Label || k.MaxConcurrent != 0 || !k.ExpiresAt.Equal(newExpiry) {
+		} else if k.Label != created.Label || k.MaxConcurrent != 1 || !k.ExpiresAt.Equal(newExpiry) {
 			t.Errorf("key has unexpected changes")
 		}
 	})

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
 	"github.com/google/uuid"
+	"golang.org/x/time/rate"
 )
 
 const (
@@ -54,13 +55,17 @@ func defaultTestKey() state.APIKey {
 	}
 }
 
+func defaultRateLimiter() *rateLimiter {
+	return NewLimiter(rate.Every(1*time.Second), 1000)
+}
+
 func newTestRouterWithKey(t *testing.T, key state.APIKey) http.Handler {
 	t.Helper()
 	reg, err := state.New(filepath.Join(t.TempDir(), "state.json"), 7001, 7010)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return NewRouter(newTestKeyStoreWithKey(t, key), reg, mockContainerService{})
+	return NewRouter(newTestKeyStoreWithKey(t, key), reg, mockContainerService{}, defaultRateLimiter())
 }
 
 func newTestRouter(t *testing.T) http.Handler {
@@ -69,7 +74,7 @@ func newTestRouter(t *testing.T) http.Handler {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return NewRouter(newTestKeyStore(t), reg, mockContainerService{})
+	return NewRouter(newTestKeyStore(t), reg, mockContainerService{}, defaultRateLimiter())
 }
 
 func newTestKeyStoreWithKeys(t *testing.T, keys ...state.APIKey) *state.KeyStore {
@@ -107,7 +112,7 @@ func newTestRouterWithKeys(t *testing.T, keys ...state.APIKey) http.Handler {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return NewRouter(newTestKeyStoreWithKeys(t, keys...), reg, mockContainerService{})
+	return NewRouter(newTestKeyStoreWithKeys(t, keys...), reg, mockContainerService{}, defaultRateLimiter())
 }
 
 func TestHealth(t *testing.T) {
@@ -174,7 +179,7 @@ func TestPostDeploymentPortExhaustion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	router := NewRouter(newTestKeyStore(t), reg, mockContainerService{})
+	router := NewRouter(newTestKeyStore(t), reg, mockContainerService{}, defaultRateLimiter())
 
 	makeRequest := func() int {
 		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
@@ -199,7 +204,7 @@ func TestStartFailureRollsBackPort(t *testing.T) {
 		t.Fatal(err)
 	}
 	mock := &failOnceMock{}
-	router := NewRouter(newTestKeyStore(t), reg, mock)
+	router := NewRouter(newTestKeyStore(t), reg, mock, defaultRateLimiter())
 
 	post := func() int {
 		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
@@ -226,7 +231,7 @@ func TestConcurrentDeployments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create registry")
 	}
-	router := NewRouter(newTestKeyStore(t), reg, mockContainerService{})
+	router := NewRouter(newTestKeyStore(t), reg, mockContainerService{}, defaultRateLimiter())
 
 	var wg sync.WaitGroup
 	for range 10 {
@@ -331,7 +336,7 @@ func TestApiKeyStates(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		router := NewRouter(newTestKeyStoreWithKey(t, key), reg, mockContainerService{})
+		router := NewRouter(newTestKeyStoreWithKey(t, key), reg, mockContainerService{}, defaultRateLimiter())
 		// 2 valid deployments, fail on the 3rd
 		if code := post(router); code != http.StatusCreated {
 			t.Errorf("expected %d, got %d", http.StatusCreated, code)
@@ -420,6 +425,43 @@ func TestDeleteDeploymentOwnership(t *testing.T) {
 		router.ServeHTTP(w, req)
 		if w.Code != http.StatusOK {
 			t.Errorf("expected %d, got %d", http.StatusOK, w.Code)
+		}
+	})
+}
+
+func TestRateLimit(t *testing.T) {
+	const userAToken = "user-a-token"
+	const userBToken = "user-b-token"
+	hashA := sha256.Sum256([]byte(userAToken))
+	hashB := sha256.Sum256([]byte(userBToken))
+
+	keyA := state.APIKey{ID: uuid.NewString(), OwnerID: "user-a", Label: "a", HashHex: hex.EncodeToString(hashA[:]), CreatedAt: time.Now()}
+	keyB := state.APIKey{ID: uuid.NewString(), OwnerID: "user-b", Label: "b", HashHex: hex.EncodeToString(hashB[:]), CreatedAt: time.Now()}
+
+	reg, err := state.New(filepath.Join(t.TempDir(), "state.json"), 7001, 7010)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	strictRateLimit := NewLimiter(rate.Every(1*time.Minute), 1)
+	router := NewRouter(newTestKeyStoreWithKeys(t, keyA, keyB), reg, mockContainerService{}, strictRateLimit)
+	post := func(key string) int {
+		req := httptest.NewRequest(http.MethodPost, "/deployment", nil)
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", key))
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	t.Run("rate-limited", func(t *testing.T) {
+		if code := post(userAToken); code != http.StatusCreated {
+			t.Errorf("expected %d, got %d", http.StatusCreated, code)
+		}
+		if code := post(userAToken); code != http.StatusTooManyRequests {
+			t.Errorf("expected %d, got %d", http.StatusTooManyRequests, code)
+		}
+		if code := post(userBToken); code != http.StatusCreated {
+			t.Errorf("expected %d, got %d", http.StatusCreated, code)
 		}
 	})
 }

--- a/provisioning/internal/api/handler.go
+++ b/provisioning/internal/api/handler.go
@@ -9,8 +9,9 @@ import (
 )
 
 type handler struct {
-	registry *state.Registry
-	service  ContainerService
+	registry    *state.Registry
+	service     ContainerService
+	rateLimiter *rateLimiter
 }
 
 type ContainerService interface {
@@ -22,15 +23,16 @@ type contextKey string
 
 const apiKeyContextKey contextKey = "apikey"
 
-func NewRouter(keys *state.KeyStore, registry *state.Registry, containerSvc ContainerService) http.Handler {
+func NewRouter(keys *state.KeyStore, registry *state.Registry, containerSvc ContainerService, rateLimiter *rateLimiter) http.Handler {
 	h := &handler{
-		registry: registry,
-		service:  containerSvc,
+		registry:    registry,
+		service:     containerSvc,
+		rateLimiter: rateLimiter,
 	}
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /health", handleHealth)
-	mux.HandleFunc("POST /deployment", h.handlePostDeployment)
+	mux.HandleFunc("POST /deployment", rateLimit(h.rateLimiter, h.handlePostDeployment))
 	mux.HandleFunc("DELETE /deployment/{slug}", h.handleDeleteDeployment)
 
 	return authRequest(keys, mux)
@@ -58,5 +60,22 @@ func authRequest(keys *state.KeyStore, next http.Handler) http.Handler {
 
 		ctx := context.WithValue(r.Context(), apiKeyContextKey, key)
 		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func rateLimit(l *rateLimiter, next http.HandlerFunc) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key, ok := r.Context().Value(apiKeyContextKey).(state.APIKey)
+		if !ok {
+			http.Error(w, "invalid context", http.StatusBadRequest)
+			return
+		}
+
+		if !l.allow(key.ID) {
+			http.Error(w, "too many requests", http.StatusTooManyRequests)
+			return
+		}
+
+		next(w, r)
 	})
 }

--- a/provisioning/internal/api/ratelimit.go
+++ b/provisioning/internal/api/ratelimit.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"sync"
+
+	"golang.org/x/time/rate"
+)
+
+type rateLimiter struct {
+	mu         sync.Mutex
+	refillRate rate.Limit
+	burstSize  int
+	limits     map[string]*rate.Limiter
+}
+
+func NewLimiter(r rate.Limit, burst int) *rateLimiter {
+	return &rateLimiter{
+		refillRate: r,
+		burstSize:  burst,
+		limits:     make(map[string]*rate.Limiter),
+	}
+}
+
+func (l *rateLimiter) allow(keyID string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	keyLimiter, ok := l.limits[keyID]
+	if !ok {
+		l.limits[keyID] = rate.NewLimiter(l.refillRate, l.burstSize)
+		keyLimiter = l.limits[keyID]
+	}
+	return keyLimiter.Allow()
+}

--- a/provisioning/internal/state/keys.go
+++ b/provisioning/internal/state/keys.go
@@ -24,8 +24,8 @@ type APIKey struct {
 	Label         string     `json:"label"` // human-redable key purpose ("internal-testing")
 	HashHex       string     `json:"hash"`  // SHA256 of key
 	CreatedAt     time.Time  `json:"created_at"`
-	ExpiresAt     *time.Time `json:"expires_at"`     // nil - does not expire
-	MaxConcurrent int        `json:"max_concurrent"` // 0 - no limit
+	ExpiresAt     *time.Time `json:"expires_at"` // nil - does not expire
+	MaxConcurrent int        `json:"max_concurrent"`
 	Revoked       bool       `json:"revoked"`
 }
 
@@ -86,6 +86,10 @@ func (ks *KeyStore) Create(ownerID, label string, maxConcurrent int, ttl *time.D
 	_, err := rand.Read(key)
 	if err != nil {
 		return APIKey{}, "", err
+	}
+
+	if maxConcurrent <= 0 {
+		return APIKey{}, "", fmt.Errorf("maxConcurrent must be greater than 0")
 	}
 
 	b64Key := base64.URLEncoding.EncodeToString(key)
@@ -163,6 +167,10 @@ func (ks *KeyStore) Update(keyID string, label *string, maxConcurrent *int, expi
 				ks.state.Keys[i].Label = *label
 			}
 			if maxConcurrent != nil {
+				if *maxConcurrent <= 0 {
+					ks.state.Keys[i] = original
+					return fmt.Errorf("maxConcurrent must be greater than 0")
+				}
 				ks.state.Keys[i].MaxConcurrent = *maxConcurrent
 			}
 			switch expiresAt.Op {

--- a/provisioning/internal/state/keys_test.go
+++ b/provisioning/internal/state/keys_test.go
@@ -166,7 +166,7 @@ func TestCreate(t *testing.T) {
 		keystore := newDefaultTestKeyStore(t)
 		ownerID := "new-owner-id"
 		label := "internal-testing"
-		maxConcurrent := 0
+		maxConcurrent := 1
 		k, b64Key, err := keystore.Create(ownerID, label, maxConcurrent, nil)
 		if err != nil {
 			t.Errorf("failed to create valid key: %v", err)
@@ -207,7 +207,7 @@ func TestCreate(t *testing.T) {
 		keystore := newDefaultTestKeyStore(t)
 		ownerID := "new-owner-id"
 		label := "internal-testing"
-		maxConcurrent := 0
+		maxConcurrent := 1
 		d := time.Duration(time.Hour)
 		ttl := &d
 		k, _, err := keystore.Create(ownerID, label, maxConcurrent, ttl)
@@ -225,6 +225,20 @@ func TestCreate(t *testing.T) {
 		}
 	})
 
+	t.Run("zero-max-concurrent-rejected", func(t *testing.T) {
+		keystore := newDefaultTestKeyStore(t)
+		if _, _, err := keystore.Create("owner", "label", 0, nil); err == nil {
+			t.Error("expected error for zero max concurrent")
+		}
+	})
+
+	t.Run("negative-max-concurrent-rejected", func(t *testing.T) {
+		keystore := newDefaultTestKeyStore(t)
+		if _, _, err := keystore.Create("owner", "label", -1, nil); err == nil {
+			t.Error("expected error for negative max concurrent")
+		}
+	})
+
 	t.Run("persistance", func(t *testing.T) {
 		path := filepath.Join(t.TempDir(), "keys.json")
 		keystore, err := state.NewKeyStore(path)
@@ -233,7 +247,7 @@ func TestCreate(t *testing.T) {
 		}
 		ownerID := "new-owner-id"
 		label := "internal-testing"
-		maxConcurrent := 0
+		maxConcurrent := 1
 		createdKey, b64Key, err := keystore.Create(ownerID, label, maxConcurrent, nil)
 		if err != nil {
 			t.Fatal(err)
@@ -258,7 +272,7 @@ func TestCreate(t *testing.T) {
 func TestRevoke(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		keyStore := newDefaultTestKeyStore(t)
-		k, b64Key, err := keyStore.Create("foo", "bar", 0, nil)
+		k, b64Key, err := keyStore.Create("foo", "bar", 1, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -288,7 +302,7 @@ func TestRevoke(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		k, b64Key, err := keystore.Create("foo", "bar", 0, nil)
+		k, b64Key, err := keystore.Create("foo", "bar", 1, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -309,7 +323,7 @@ func TestRevoke(t *testing.T) {
 
 	t.Run("already-revoked", func(t *testing.T) {
 		keyStore := newDefaultTestKeyStore(t)
-		k, _, err := keyStore.Create("foo", "bar", 0, nil)
+		k, _, err := keyStore.Create("foo", "bar", 1, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -327,7 +341,7 @@ func TestRevoke(t *testing.T) {
 func TestUpdate(t *testing.T) {
 	t.Run("update-label", func(t *testing.T) {
 		keyStore := newDefaultTestKeyStore(t)
-		k, b64Key, err := keyStore.Create("foo", "original-label", 0, nil)
+		k, b64Key, err := keyStore.Create("foo", "original-label", 1, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -350,7 +364,7 @@ func TestUpdate(t *testing.T) {
 
 	t.Run("update-max-concurrent", func(t *testing.T) {
 		keyStore := newDefaultTestKeyStore(t)
-		k, b64Key, err := keyStore.Create("foo", "original-label", 0, nil)
+		k, b64Key, err := keyStore.Create("foo", "original-label", 1, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -371,9 +385,31 @@ func TestUpdate(t *testing.T) {
 		}
 	})
 
+	t.Run("zero-max-concurrent-rejected", func(t *testing.T) {
+		keyStore := newDefaultTestKeyStore(t)
+		k, b64Key, err := keyStore.Create("foo", "original-label", 1, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		zero := 0
+		if err := keyStore.Update(k.ID, nil, &zero, state.ExpiryUpdate{Op: state.ExpiryNoChange}); err == nil {
+			t.Error("expected error for zero max concurrent")
+		}
+
+		keyHash := sha256.Sum256([]byte(b64Key))
+		found, ok := keyStore.Lookup(keyHash)
+		if !ok {
+			t.Fatal("failed to find key")
+		}
+		if found.MaxConcurrent != 1 {
+			t.Error("rejected update should not change stored MaxConcurrent")
+		}
+	})
+
 	t.Run("set-expiry", func(t *testing.T) {
 		keyStore := newDefaultTestKeyStore(t)
-		k, b64Key, err := keyStore.Create("foo", "original-label", 0, nil)
+		k, b64Key, err := keyStore.Create("foo", "original-label", 1, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -404,7 +440,7 @@ func TestUpdate(t *testing.T) {
 	t.Run("clear-expiry", func(t *testing.T) {
 		keyStore := newDefaultTestKeyStore(t)
 		ttl := time.Hour
-		k, b64Key, err := keyStore.Create("foo", "original-label", 0, &ttl)
+		k, b64Key, err := keyStore.Create("foo", "original-label", 1, &ttl)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
## Summary
Fixes: Multi-tenant DoS: max_concurrent = 0 means unlimited; no global cap; no rate limiting; one key can exhaust the whole port pool