### PR TITLE
Fix: FRP tokens stored in plaintext

### DIFF
--- a/provisioning/internal/api/deployment.go
+++ b/provisioning/internal/api/deployment.go
@@ -33,13 +33,13 @@ func (h *handler) handlePostDeployment(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	d, err := h.registry.AllocatePort(slug, token, key.OwnerID, key.MaxConcurrent)
+	d, err := h.registry.AllocatePort(slug, key.OwnerID, key.MaxConcurrent)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("failed to allocate port: %v", err), http.StatusInternalServerError)
 		return
 	}
 
-	if err := h.service.Start(d); err != nil {
+	if err := h.service.Start(d, token); err != nil {
 		http.Error(w, fmt.Sprintf("failed to start container: %v", err), http.StatusInternalServerError)
 		h.registry.Release(slug)
 		return

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -26,12 +26,12 @@ const (
 
 type mockContainerService struct{}
 
-func (mockContainerService) Start(state.Deployment) error { return nil }
-func (mockContainerService) Stop(string) error            { return nil }
+func (mockContainerService) Start(state.Deployment, string) error { return nil }
+func (mockContainerService) Stop(string) error                    { return nil }
 
 type failOnceMock struct{ calls int }
 
-func (m *failOnceMock) Start(state.Deployment) error {
+func (m *failOnceMock) Start(state.Deployment, string) error {
 	m.calls++
 	if m.calls == 1 {
 		return fmt.Errorf("simulated start failure")

--- a/provisioning/internal/api/handler.go
+++ b/provisioning/internal/api/handler.go
@@ -15,7 +15,7 @@ type handler struct {
 }
 
 type ContainerService interface {
-	Start(d state.Deployment) error
+	Start(d state.Deployment, token string) error
 	Stop(slug string) error
 }
 

--- a/provisioning/internal/docker/container.go
+++ b/provisioning/internal/docker/container.go
@@ -36,8 +36,8 @@ func PullImage(imageName string) error {
 	return output.Close()
 }
 
-func (m Manager) Start(d state.Deployment) error {
-	configPath, err := writeConfig(d)
+func (m Manager) Start(d state.Deployment, token string) error {
+	configPath, err := writeConfig(d, token)
 	if err != nil {
 		return fmt.Errorf("failed to write frps config file: %w", err)
 	}
@@ -82,7 +82,7 @@ func (m Manager) Start(d state.Deployment) error {
 	return client.ContainerStart(ctx, resp.ID, container.StartOptions{})
 }
 
-func writeConfig(d state.Deployment) (string, error) {
+func writeConfig(d state.Deployment, token string) (string, error) {
 	hostDataPath := os.Getenv("HOST_DATA_PATH")
 	if hostDataPath == "" {
 		return "", fmt.Errorf("HOST_DATA_PATH not set")
@@ -94,7 +94,7 @@ func writeConfig(d state.Deployment) (string, error) {
 	}
 
 	path := filepath.Join(dir, "frps.toml")
-	content := fmt.Sprintf("bindPort = 7000\nauth.token = %q\nvhostHTTPPort = 8080\n", d.Token)
+	content := fmt.Sprintf("bindPort = 7000\nauth.token = %q\nvhostHTTPPort = 8080\n", token)
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		return "", err
 	}

--- a/provisioning/internal/docker/container.go
+++ b/provisioning/internal/docker/container.go
@@ -37,7 +37,7 @@ func PullImage(imageName string) error {
 }
 
 func (m Manager) Start(d state.Deployment, token string) error {
-	configPath, err := writeConfig(d, token)
+	configPath, err := writeConfig(d)
 	if err != nil {
 		return fmt.Errorf("failed to write frps config file: %w", err)
 	}
@@ -52,6 +52,7 @@ func (m Manager) Start(d state.Deployment, token string) error {
 	resp, err := client.ContainerCreate(ctx,
 		&container.Config{
 			Image: m.FrpsImage,
+			Env:   []string{fmt.Sprintf("FRP_TOKEN=%s", token)},
 			Labels: map[string]string{
 				"traefik.enable": "true",
 				fmt.Sprintf("traefik.http.routers.%s.rule", d.Slug):                      fmt.Sprintf("Host(`%s.tunnels.%s`)", d.Slug, meshDomain),
@@ -82,7 +83,7 @@ func (m Manager) Start(d state.Deployment, token string) error {
 	return client.ContainerStart(ctx, resp.ID, container.StartOptions{})
 }
 
-func writeConfig(d state.Deployment, token string) (string, error) {
+func writeConfig(d state.Deployment) (string, error) {
 	hostDataPath := os.Getenv("HOST_DATA_PATH")
 	if hostDataPath == "" {
 		return "", fmt.Errorf("HOST_DATA_PATH not set")
@@ -94,7 +95,7 @@ func writeConfig(d state.Deployment, token string) (string, error) {
 	}
 
 	path := filepath.Join(dir, "frps.toml")
-	content := fmt.Sprintf("bindPort = 7000\nauth.token = %q\nvhostHTTPPort = 8080\n", token)
+	content := "bindPort = 7000\nauth.token = \"{{ .Envs.FRP_TOKEN }}\"\nvhostHTTPPort = 8080\n"
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		return "", err
 	}

--- a/provisioning/internal/state/registry.go
+++ b/provisioning/internal/state/registry.go
@@ -14,7 +14,6 @@ import (
 
 type Deployment struct {
 	Slug      string    `json:"slug"`
-	Token     string    `json:"token"`
 	FrpsPort  int       `json:"frps_port"`
 	CreatedAt time.Time `json:"created_at"`
 	OwnerID   string    `json:"owner_id"`
@@ -48,7 +47,7 @@ func New(path string, portMin, portMax int) (*Registry, error) {
 	return r, nil
 }
 
-func (r *Registry) AllocatePort(slug, token, ownerID string, maxConcurrent int) (Deployment, error) {
+func (r *Registry) AllocatePort(slug, ownerID string, maxConcurrent int) (Deployment, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -69,7 +68,6 @@ func (r *Registry) AllocatePort(slug, token, ownerID string, maxConcurrent int) 
 		if !used[port] {
 			d := Deployment{
 				Slug:      slug,
-				Token:     token,
 				FrpsPort:  port,
 				CreatedAt: time.Now().UTC(),
 				OwnerID:   ownerID,

--- a/provisioning/internal/state/registry_test.go
+++ b/provisioning/internal/state/registry_test.go
@@ -26,7 +26,7 @@ func defaultTestRegistry(t *testing.T) *state.Registry {
 func TestAllocatePort(t *testing.T) {
 	reg := defaultTestRegistry(t)
 
-	created, err := reg.AllocatePort(testSlug, "test-token", "test-owner", 0)
+	created, err := reg.AllocatePort(testSlug, "test-owner", 0)
 	if err != nil {
 		t.Errorf("expected valid allocation")
 	}
@@ -53,7 +53,7 @@ func TestAllocatePort(t *testing.T) {
 
 func TestRelease(t *testing.T) {
 	reg := defaultTestRegistry(t)
-	d, err := reg.AllocatePort(testSlug, "test-token", "test-owner", 0)
+	d, err := reg.AllocatePort(testSlug, "test-owner", 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,11 +79,11 @@ func TestMaxConcurrent(t *testing.T) {
 	t.Run("single-owner", func(t *testing.T) {
 		const maxDeploys = 1
 		reg := defaultTestRegistry(t)
-		if _, err := reg.AllocatePort("testSlug-A", "test-token", "test-owner", maxDeploys); err != nil {
+		if _, err := reg.AllocatePort("testSlug-A", "test-owner", maxDeploys); err != nil {
 			t.Fatal(err)
 		}
 
-		if _, err := reg.AllocatePort("testSlug-B", "test-token", "test-owner", maxDeploys); err == nil {
+		if _, err := reg.AllocatePort("testSlug-B", "test-owner", maxDeploys); err == nil {
 			t.Errorf("deployed more than %d max deployments", maxDeploys)
 		}
 	})
@@ -91,19 +91,19 @@ func TestMaxConcurrent(t *testing.T) {
 	t.Run("multiple-owners", func(t *testing.T) {
 		const maxDeploys = 1
 		reg := defaultTestRegistry(t)
-		if _, err := reg.AllocatePort("testSlug-A", "test-token", "test-owner-0", maxDeploys); err != nil {
+		if _, err := reg.AllocatePort("testSlug-A", "test-owner-0", maxDeploys); err != nil {
 			t.Fatal(err)
 		}
 
-		if _, err := reg.AllocatePort("testSlug-B", "test-token", "test-owner-1", maxDeploys); err != nil {
+		if _, err := reg.AllocatePort("testSlug-B", "test-owner-1", maxDeploys); err != nil {
 			t.Fatal(err)
 		}
 
-		if _, err := reg.AllocatePort("testSlug-C", "test-token", "test-owner-0", maxDeploys); err == nil {
+		if _, err := reg.AllocatePort("testSlug-C", "test-owner-0", maxDeploys); err == nil {
 			t.Errorf("test-owner-0 deployed more than %d max deployments", maxDeploys)
 		}
 
-		if _, err := reg.AllocatePort("testSlug-D", "test-token", "test-owner-1", maxDeploys); err == nil {
+		if _, err := reg.AllocatePort("testSlug-D", "test-owner-1", maxDeploys); err == nil {
 			t.Errorf("test-owner-1 deployed more than %d max deployments", maxDeploys)
 		}
 	})
@@ -115,7 +115,7 @@ func TestRegistryPersistence(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	created, err := reg.AllocatePort(testSlug, "test-token", "test-owner", 0)
+	created, err := reg.AllocatePort(testSlug, "test-owner", 0)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
Fixes: M3 | Medium | frp deployment tokens stored in plaintext at rest in state.json (API keys are correctly hashed — inconsistent) 
 

Removed them from the state.json file entirely - never reused, never looked up, just not needed.