### PR TITLE
Limit admin-api body size

### DIFF
--- a/provisioning/internal/adminapi/handler.go
+++ b/provisioning/internal/adminapi/handler.go
@@ -52,6 +52,8 @@ type handler struct {
 	keys *state.KeyStore
 }
 
+const maxBodyBytes = 1 << 20 // 1 MiB
+
 func NewAdminRouter(keys *state.KeyStore, adminToken string) http.Handler {
 	h := &handler{
 		keys: keys,
@@ -63,7 +65,7 @@ func NewAdminRouter(keys *state.KeyStore, adminToken string) http.Handler {
 	mux.HandleFunc("DELETE /keys/{key_id}", h.handleDeleteKey)
 	mux.HandleFunc("PATCH /keys/{key_id}", h.handlePatchKey)
 
-	return authRequest(adminToken, mux)
+	return authRequest(adminToken, limitBody(mux))
 }
 
 func authRequest(adminToken string, next http.Handler) http.Handler {
@@ -81,6 +83,13 @@ func authRequest(adminToken string, next http.Handler) http.Handler {
 			return
 		}
 
+		next.ServeHTTP(w, r)
+	})
+}
+
+func limitBody(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
 		next.ServeHTTP(w, r)
 	})
 }

--- a/provisioning/internal/adminapi/handler_test.go
+++ b/provisioning/internal/adminapi/handler_test.go
@@ -433,6 +433,55 @@ func TestPatchKey(t *testing.T) {
 	})
 }
 
+func TestBodySizeLimit(t *testing.T) {
+	t.Run("oversized body rejected", func(t *testing.T) {
+		requestData := createKeyRequest{
+			OwnerID:       "owner",
+			Label:         string(bytes.Repeat([]byte("a"), maxBodyBytes)),
+			MaxConcurrent: 1,
+		}
+		b, err := json.Marshal(&requestData)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		req := newAuthedRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
+		w := httptest.NewRecorder()
+		newTestAdminRouter(t).ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("expected %d, got %d", http.StatusBadRequest, w.Code)
+		}
+	})
+
+	t.Run("body at limit accepted", func(t *testing.T) {
+		empty, err := json.Marshal(&createKeyRequest{OwnerID: "owner", MaxConcurrent: 1})
+		if err != nil {
+			t.Fatal(err)
+		}
+		overhead := len(empty)
+
+		requestData := createKeyRequest{
+			OwnerID:       "owner",
+			Label:         string(bytes.Repeat([]byte("a"), maxBodyBytes-overhead)),
+			MaxConcurrent: 1,
+		}
+		b, err := json.Marshal(&requestData)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(b) != maxBodyBytes {
+			t.Fatalf("test body is %d bytes, want exactly maxBodyBytes (%d)", len(b), maxBodyBytes)
+		}
+
+		req := newAuthedRequest(http.MethodPost, "/keys", bytes.NewBuffer(b))
+		w := httptest.NewRecorder()
+		newTestAdminRouter(t).ServeHTTP(w, req)
+		if w.Code != http.StatusCreated {
+			t.Errorf("expected %d, got %d", http.StatusCreated, w.Code)
+		}
+	})
+}
+
 func TestAdminAuth(t *testing.T) {
 	router := newTestAdminRouter(t)
 


### PR DESCRIPTION
## Summary
Fixes: L3	Low	Admin API has no request-body size limit (unauth + unbounded → memory DoS)