### PR TITLE
Add optional bind interface for frps containers

### DIFF
--- a/provisioning/cmd/worker/main.go
+++ b/provisioning/cmd/worker/main.go
@@ -24,11 +24,17 @@ func main() {
 		log.Fatal("WORKER_TOKEN must be set")
 	}
 
+	// Empty string defaults to "0.0.0.0"
+	frpsBindAddr := os.Getenv("FRPS_BIND_ADDR")
+
 	if err := docker.PullImage(frpsImage); err != nil {
 		log.Fatalf("failed to pull frps image: %v", err)
 	}
 
-	runner := docker.Manager{FrpsImage: frpsImage}
+	runner := docker.Manager{
+		FrpsBindAddr: frpsBindAddr,
+		FrpsImage:    frpsImage,
+	}
 
 	srv := &http.Server{
 		Addr:         ":8081",

--- a/provisioning/internal/docker/container.go
+++ b/provisioning/internal/docker/container.go
@@ -17,7 +17,8 @@ import (
 const meshDomain = "meshforensics.app"
 
 type Manager struct {
-	FrpsImage string
+	FrpsImage    string
+	FrpsBindAddr string
 }
 
 func PullImage(imageName string) error {
@@ -68,7 +69,10 @@ func (m Manager) Start(d state.Deployment, token string) error {
 			RestartPolicy: container.RestartPolicy{Name: container.RestartPolicyUnlessStopped},
 			Binds:         []string{fmt.Sprintf("%s:/etc/frp/frps.toml:ro", configPath)},
 			PortBindings: nat.PortMap{
-				nat.Port("7000/tcp"): []nat.PortBinding{{HostPort: fmt.Sprintf("%d", d.FrpsPort)}},
+				nat.Port("7000/tcp"): []nat.PortBinding{{
+					HostIP:   m.FrpsBindAddr,
+					HostPort: fmt.Sprintf("%d", d.FrpsPort),
+				}},
 			},
 		},
 		nil, nil, fmt.Sprintf("frps-%s", d.Slug))

--- a/provisioning/worker.env.example
+++ b/provisioning/worker.env.example
@@ -1,2 +1,3 @@
 FRPS_IMAGE=snowdreamtech/frps:latest
+FRPS_BIND_ADDR=<host public IP> #optional: restricts frps host ports to this interface instead of 0.0.0.0
 WORKER_TOKEN=generate with `openssl rand -hex 32`


### PR DESCRIPTION
## Summary
Fixes: frp host ports bound to 0.0.0.0 across the whole range (100+ ports on all interfaces)

Internally `""` defaults to 0.0.0.0