### PR TITLE
restore android CI build restrictions

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -5,8 +5,11 @@ on:
     tags:
       - 'v*'  # Triggers on version tags like v0.1.0, v1.0.0-alpha.1, etc.
   pull_request:  # Build-only: verify reproducibility without publishing
-    branches: 
-      - main
+    paths:
+      - 'android-client/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/android-release.yml'
   workflow_dispatch:  # Allows manual trigger from GitHub UI
     inputs:
       version:


### PR DESCRIPTION
## Summary
An Android release is currently building for every change pushed to main regardless if any changes have been made to relevant source files. This change restores the original CI job restriction to only run if Android-related files are updated