### PR TITLE
skip user confirmation for mesh configuration

### DIFF
--- a/Taskfile.dev.yml
+++ b/Taskfile.dev.yml
@@ -11,11 +11,6 @@ silent: true
 
 tasks:
 
-  promptConfirmDotEnv:
-    prompt: Does the above configuration look correct?
-    deps:
-      - printDotEnv
-
 #################################
 # Development tasks
 #################################
@@ -98,10 +93,6 @@ tasks:
 # Internal tasks
 #################################
 
-  printDotEnv:
-    internal: true
-    cmd: echo ""; cat .env; echo ""
-  
   submoduleInit:
     internal: true
     cmd: git submodule update --init --recursive

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -129,7 +129,7 @@ tasks:
   confirmDotEnv:
     cmds:
       - defer: '{{if .EXIT_CODE}}rm -f .env && printf "\033[1;33mConfiguration cleared. Run task controlPlane to start again.\033[0m\n"{{end}}'
-      - task -t Taskfile.dev.yml promptConfirmDotEnv 2>/dev/null
+      - task confirmConfig 2>/dev/null
 
   controlPlaneType:
     internal: true
@@ -366,3 +366,12 @@ tasks:
   createDotEnv:
     internal: true
     cmd: '[ -f .env ] || (touch .env && chmod 600 .env)'
+
+  confirmConfig:
+    cmds:
+      - |
+        printf "\033[1;36mConfiguration:\033[0m\n"
+        printf "Control plane type : {{.CONTROL_PLANE_TYPE}}\n"
+        printf "Proxy domain type  : {{.PROXY_DOMAIN_TYPE}}\n"
+        printf "Control plane URL  : {{.CONTROL_PLANE_URL}}\n"
+        printf "\n"


### PR DESCRIPTION
## Summary
Rather than prompting the user to confirm their control plane configuration (info which is largely irrelevant to users) we simply print relevant values and attempt setup as if a user gave a positive response.

Example:  
<img width="1417" height="885" alt="image" src="https://github.com/user-attachments/assets/e675d713-a3b5-4c18-89e4-e3012c677acc" />
