### PR TITLE
Add hot-reloading for provisioner API Keys

### DIFF
--- a/provisioning/internal/state/keys.go
+++ b/provisioning/internal/state/keys.go
@@ -53,6 +53,10 @@ func (ks *KeyStore) Lookup(hash [32]byte) (APIKey, bool) {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
 
+	if err := ks.reload(); err != nil {
+		// log error, lookup keys in memory
+	}
+
 	for _, k := range ks.state.Keys {
 		decoded, err := hex.DecodeString(k.HashHex)
 		if err != nil {
@@ -188,6 +192,9 @@ func (ks *KeyStore) Update(keyID string, label *string, maxConcurrent *int, expi
 func (ks *KeyStore) List() []APIKey {
 	ks.mu.Lock()
 	defer ks.mu.Unlock()
+	if err := ks.reload(); err != nil {
+		// log error but list keys in memory
+	}
 	out := make([]APIKey, len(ks.state.Keys))
 	copy(out, ks.state.Keys)
 	return out
@@ -199,4 +206,13 @@ func (ks *KeyStore) load() error {
 
 func (ks *KeyStore) save() error {
 	return saveJSON(ks.path, ks.state)
+}
+
+func (ks *KeyStore) reload() error {
+	loaded := keysState{}
+	if err := loadJSON(ks.path, &loaded); err != nil {
+		return err
+	}
+	ks.state = loaded
+	return nil
 }

--- a/provisioning/internal/state/keys_test.go
+++ b/provisioning/internal/state/keys_test.go
@@ -467,3 +467,82 @@ func TestUpdate(t *testing.T) {
 		}
 	})
 }
+
+func TestReload(t *testing.T) {
+	t.Run("valid-key-added", func(t *testing.T) {
+		data, err := json.Marshal(struct {
+			Keys []state.APIKey `json:"keys"`
+		}{Keys: []state.APIKey{defaultTestKey()}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(t.TempDir(), "keys.json")
+		if err := os.WriteFile(path, data, 0600); err != nil {
+			t.Fatal(err)
+		}
+		ks, err := state.NewKeyStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var keys struct {
+			Keys []state.APIKey `json:"keys"`
+		}
+		if err := json.Unmarshal(b, &keys); err != nil {
+			t.Fatal(err)
+		}
+		newKeyHash := sha256.Sum256([]byte("new-key"))
+		newKey := state.APIKey{
+			ID:      uuid.NewString(),
+			HashHex: hex.EncodeToString(newKeyHash[:]),
+		}
+		keys.Keys = append(keys.Keys, newKey)
+		d, err := json.Marshal(keys)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, d, 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, ok := ks.Lookup(newKeyHash); !ok {
+			t.Error("failed to lookup key added by admin")
+		}
+	})
+
+	t.Run("unexpected-json-saved", func(t *testing.T) {
+		data, err := json.Marshal(struct {
+			Keys []state.APIKey `json:"keys"`
+		}{Keys: []state.APIKey{defaultTestKey()}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(t.TempDir(), "keys.json")
+		if err := os.WriteFile(path, data, 0600); err != nil {
+			t.Fatal(err)
+		}
+		ks, err := state.NewKeyStore(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var brokenStruct struct {
+			Keys []state.APIKey `json:"broken"`
+		}
+		d, err := json.Marshal(brokenStruct)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, d, 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, ok := ks.Lookup(defaultKeyHash()); !ok {
+			t.Error("failed to lookup existing valid key in memory")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Simple reloading of the keys file on disk to pickup newly created API Keys from the admin API without having to restart the container stack

Closes #284 