### PR TITLE
derive control plane api key expiry from provisioned domain expiry

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -67,7 +67,8 @@ tasks:
   apikey:
     desc: Generate a Headscale API key
     cmd: >
-      docker compose exec headscale headscale apikeys create --expiration {{.API_KEY_EXPIRATION}} ||
+      { [ -f .env ] && . ./.env; docker compose exec headscale headscale apikeys create
+      --expiration "${HEADSCALE_API_KEY_EXPIRATION:-{{.API_KEY_EXPIRATION}}}"; } ||
       echo "Control plane is not running locally. Either start it with 'task controlPlane' first or
         run 'task apikey' on the control plane server."
 
@@ -122,9 +123,11 @@ tasks:
     internal: true
     cmds:
       - |
-        KEY=$(docker compose exec -T headscale headscale apikeys create --expiration {{.API_KEY_EXPIRATION}})
+        [ -f .env ] && . ./.env
+        KEY=$(docker compose exec -T headscale headscale apikeys create --expiration "${HEADSCALE_API_KEY_EXPIRATION:-{{.API_KEY_EXPIRATION}}}")
         printf "\033[1;37mControl plane API key (enter this in the web UI to log in):\033[0m\n"
         printf "\033[1;32m$KEY\033[0m\n"
+        printf "\033[1;35mThis key expires in ${HEADSCALE_API_KEY_EXPIRATION:-{{.API_KEY_EXPIRATION}}}. When it does, run 'task apikey' on the control plane for a new one - your network and domain are unaffected.\033[0m\n"
 
   confirmDotEnv:
     cmds:
@@ -262,7 +265,16 @@ tasks:
         FRP_SLUG=$(echo "$RESPONSE" | jq -r '.slug')
         FRP_TOKEN=$(echo "$RESPONSE" | jq -r '.token')
         FRP_PORT=$(echo "$RESPONSE" | jq -r '.frps_port')
+        DEPLOYMENT_TTL_SECONDS=$(echo "$RESPONSE" | jq -r '.expires_in_seconds')
         printf "\033[1;32mCreated deployment $FRP_SLUG\n\n"
+        # Set the Headscale API key lifetime to match the deployment's plus a 2h margin
+        # so the key never expires before the domain.
+        if [ "$DEPLOYMENT_TTL_SECONDS" -gt 0 ] 2>/dev/null; then
+          KEY_TTL_HOURS=$((DEPLOYMENT_TTL_SECONDS / 3600 + 2))
+          echo "HEADSCALE_API_KEY_EXPIRATION=${KEY_TTL_HOURS}h" >> .env
+        else
+          printf "\033[1;33mCould not read deployment expiry; using default API key lifetime.\033[0m\n"
+        fi
         sed -e "s|FRP_HOST|$FRP_HOST|g" \
             -e "s|FRP_PORT|$FRP_PORT|g" \
             -e "s|FRP_AUTH_TOKEN|$FRP_TOKEN|g" \

--- a/provisioning/internal/api/deployment.go
+++ b/provisioning/internal/api/deployment.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"regexp"
+	"time"
 
 	"github.com/BARGHEST-ngo/MESH/provisioning/internal/state"
 )
@@ -48,9 +49,10 @@ func (h *handler) handlePostDeployment(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := &DeploymentResponse{
-		Slug:     slug,
-		Token:    token,
-		FrpsPort: d.FrpsPort,
+		Slug:             slug,
+		Token:            token,
+		FrpsPort:         d.FrpsPort,
+		ExpiresInSeconds: int(time.Until(d.ExpiresAt).Seconds()),
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -173,6 +173,19 @@ func TestPostDeploymentStructure(t *testing.T) {
 	if d.FrpsPort < minPort || d.FrpsPort > maxPort {
 		t.Errorf("expected valid port")
 	}
+
+	if d.ExpiresAt.IsZero() {
+		t.Errorf("expected non-zero expiry")
+	}
+
+	wantExpiry := time.Now().Add(deployTTL)
+	if delta := d.ExpiresAt.Sub(wantExpiry); delta < -time.Minute || delta > time.Minute {
+		t.Errorf("expected expiry near %v, got %v", wantExpiry, d.ExpiresAt)
+	}
+
+	if delta := d.ExpiresInSeconds - int(deployTTL.Seconds()); delta < -60 || delta > 60 {
+		t.Errorf("expected expires_in_seconds near %d, got %d", int(deployTTL.Seconds()), d.ExpiresInSeconds)
+	}
 }
 
 func TestPostDeploymentPortExhaustion(t *testing.T) {

--- a/provisioning/internal/api/deployment_test.go
+++ b/provisioning/internal/api/deployment_test.go
@@ -174,17 +174,9 @@ func TestPostDeploymentStructure(t *testing.T) {
 		t.Errorf("expected valid port")
 	}
 
-	if d.ExpiresAt.IsZero() {
-		t.Errorf("expected non-zero expiry")
-	}
-
-	wantExpiry := time.Now().Add(deployTTL)
-	if delta := d.ExpiresAt.Sub(wantExpiry); delta < -time.Minute || delta > time.Minute {
-		t.Errorf("expected expiry near %v, got %v", wantExpiry, d.ExpiresAt)
-	}
-
-	if delta := d.ExpiresInSeconds - int(deployTTL.Seconds()); delta < -60 || delta > 60 {
-		t.Errorf("expected expires_in_seconds near %d, got %d", int(deployTTL.Seconds()), d.ExpiresInSeconds)
+	wantTTL := int(deployTTL.Seconds())
+	if delta := d.ExpiresInSeconds - wantTTL; delta < -60 || delta > 60 {
+		t.Errorf("expected expires_in_seconds near %d, got %d", wantTTL, d.ExpiresInSeconds)
 	}
 }
 

--- a/provisioning/internal/api/types.go
+++ b/provisioning/internal/api/types.go
@@ -3,7 +3,8 @@ package api
 type DeploymentRequest struct{}
 
 type DeploymentResponse struct {
-	Slug     string `json:"slug"`
-	Token    string `json:"token"`
-	FrpsPort int    `json:"frps_port"`
+	Slug             string `json:"slug"`
+	Token            string `json:"token"`
+	FrpsPort         int    `json:"frps_port"`
+	ExpiresInSeconds int    `json:"expires_in_seconds"`
 }


### PR DESCRIPTION
## Summary
Closes #300 
Seconds returned from API rather than hours so we don't lose precision when rounding 2.5 hours for example.

Headscale / Control Plane key expiry will match the deployed domain TTL (+2 hours) so it never expires before the domain