### PR TITLE
fix hardcoded domain in frpc config

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -285,6 +285,7 @@ tasks:
             -e "s|FRP_PORT|$FRP_PORT|g" \
             -e "s|FRP_AUTH_TOKEN|$FRP_TOKEN|g" \
             -e "s|FRP_SLUG|$FRP_SLUG|g" \
+            -e "s|TUNNEL_DOMAIN|$TUNNEL_DOMAIN|g" \
             control-plane/frpc.toml.example > control-plane/frpc.toml
         sed -e "s|CONTROL_PLANE_URL|https://$FRP_SLUG.$TUNNEL_DOMAIN|g" \
             control-plane/headscale/config.example.yaml > control-plane/headscale/config.yaml

--- a/control-plane/frpc.toml.example
+++ b/control-plane/frpc.toml.example
@@ -8,4 +8,4 @@ name = "mesh"
 type = "http"
 localIP = "ui"
 localPort = 8080
-customDomains = ["FRP_SLUG.tunnels.meshforensics.app"]
+customDomains = ["FRP_SLUG.TUNNEL_DOMAIN"]


### PR DESCRIPTION
## Summary
frpc toml file now uses the appropriate base domain for staging and production